### PR TITLE
bugfix-splunk-use-initd-variable

### DIFF
--- a/roles/splunk/handlers/main.yml
+++ b/roles/splunk/handlers/main.yml
@@ -13,7 +13,7 @@
     - ulimit -Sn 32768
   become: yes
   ignore_errors: true
-  when: splunk_use_initd == "true" and ansible_os_family == "RedHat" and ansible_distribution_major_version|int > 6
+  when: splunk_use_initd and ansible_os_family == "RedHat" and ansible_distribution_major_version|int > 6
 
 - name: stop splunk
   service:

--- a/roles/splunk/tasks/configure_splunk_boot.yml
+++ b/roles/splunk/tasks/configure_splunk_boot.yml
@@ -2,11 +2,11 @@
 - name: enable splunk boot-start via initd
   shell: "{{ splunk_home }}/bin/splunk enable boot-start -user {{ splunk_nix_user }} -systemd-managed 0 --answer-yes --auto-ports --no-prompt --accept-license"
   become: yes
-  when: splunk_use_initd == "true"
+  when: splunk_use_initd
   notify:
     - set ulimits in init.d
 
 - name: enable splunk boot-start via systemd
   shell: "{{ splunk_home }}/bin/splunk enable boot-start -user {{ splunk_nix_user }} -systemd-managed 1 --answer-yes --auto-ports --no-prompt --accept-license"
   become: yes
-  when: splunk_use_initd == "false"
+  when: not splunk_use_initd


### PR DESCRIPTION
**BUGFIX**
- `splunk_use_initd` variable is boolean, but it was being compared as string (e.g. `splunk_use_initd == "true"`)
- Made minor changes on that variable to allow Splunk properly configure init script (SystemV or Systemd)