### PR TITLE
fix-auditd-and-facls

### DIFF
--- a/roles/splunk/handlers/main.yml
+++ b/roles/splunk/handlers/main.yml
@@ -13,7 +13,7 @@
     - ulimit -Sn 32768
   become: yes
   ignore_errors: true
-  when: splunk_use_initd == "true" and ansible_os_family == "RedHat" and ansible_distribution_major_version|int > 6
+  when: splunk_use_initd and ansible_os_family == "RedHat" and ansible_distribution_major_version|int > 6
 
 - name: stop splunk
   service:

--- a/roles/splunk/handlers/main.yml
+++ b/roles/splunk/handlers/main.yml
@@ -64,8 +64,6 @@
   become: yes
 
 - name: restart auditd service
-  service:
-    name: auditd
-    state: restarted
+  command: service auditd condrestart
   become: yes
-  ignore_errors: true
+

--- a/roles/splunk/tasks/configure_facl.yml
+++ b/roles/splunk/tasks/configure_facl.yml
@@ -1,13 +1,24 @@
 ---
 - name: Configure file access control list (facl) settings for splunk user
   block:
-  - name: Set facl to allow splunk user to read /var/log
+  - name: Set default facl to allow splunk user to read /var/log
     acl:
       path: /var/log
       entity: "{{ splunk_nix_user }}"
       etype: user
       permissions: rx
       default: yes
+      recursive: yes
+      state: present
+    become: yes
+
+  - name: Set effective facl to allow splunk user to read /var/log
+    acl:
+      path: /var/log
+      entity: "{{ splunk_nix_user }}"
+      etype: user
+      permissions: rx
+      default: no
       recursive: yes
       state: present
     become: yes
@@ -20,6 +31,12 @@
       group: root
     become: yes
 
+  - name: Check if auditd.conf is present
+    stat:
+      path: /etc/audit/auditd.conf
+    register: result_auditd_conf
+    become: yes
+
   - name: Allow splunk to read /var/log/audit.log
     ini_file:
       path: /etc/audit/auditd.conf
@@ -29,5 +46,6 @@
     become: yes
     notify: restart auditd service
     ignore_errors: true
+    when: result_auditd_conf.stat.exists
 
   when: splunk_nix_user != 'root'

--- a/roles/splunk/tasks/configure_facl.yml
+++ b/roles/splunk/tasks/configure_facl.yml
@@ -7,21 +7,13 @@
       entity: "{{ splunk_nix_user }}"
       etype: user
       permissions: rx
-      default: yes
+      default: "{{ item }}"
       recursive: yes
       state: present
     become: yes
-
-  - name: Set effective facl to allow splunk user to read /var/log
-    acl:
-      path: /var/log
-      entity: "{{ splunk_nix_user }}"
-      etype: user
-      permissions: rx
-      default: no
-      recursive: yes
-      state: present
-    become: yes
+    loop:
+      - yes
+      - no
 
   - name: Add logrotate script to enforce splunk user facls
     template:

--- a/roles/splunk/tasks/configure_splunk_boot.yml
+++ b/roles/splunk/tasks/configure_splunk_boot.yml
@@ -2,11 +2,11 @@
 - name: enable splunk boot-start via initd
   shell: "{{ splunk_home }}/bin/splunk enable boot-start -user {{ splunk_nix_user }} -systemd-managed 0 --answer-yes --auto-ports --no-prompt --accept-license"
   become: yes
-  when: splunk_use_initd == "true"
+  when: splunk_use_initd
   notify:
     - set ulimits in init.d
 
 - name: enable splunk boot-start via systemd
   shell: "{{ splunk_home }}/bin/splunk enable boot-start -user {{ splunk_nix_user }} -systemd-managed 1 --answer-yes --auto-ports --no-prompt --accept-license"
   become: yes
-  when: splunk_use_initd == "false"
+  when: not splunk_use_initd


### PR DESCRIPTION
**BUGFIXES**
- Task added to check if *auditd.conf* exists before attempting to make changes on it
- Task added to add effective ACLs on */var/log/**
- Handler for restarting auditd modified to use `service auditd condrestart` as it seems the only valid way to restarting such service