### PR TITLE
Squashed another systemd bug related to full installs and added SHC deployment support

### DIFF
--- a/playbooks/splunk_shc_deploy.yml
+++ b/playbooks/splunk_shc_deploy.yml
@@ -1,0 +1,36 @@
+# Example playbook to install splunk and configure a basic SHC
+# Ensure that the following vars are configured: ansible_user, ansible_ssh_private_key_file, splunk_admin_password, splunk_user_seed: true
+- hosts:
+    - shdeployer
+  roles:
+    - ../roles/splunk
+  vars:
+    - deployment_task: check_splunk.yml
+
+- hosts:
+    - shdeployer
+  roles:
+    - ../roles/splunk
+  vars:
+    - deployment_task: configure_shc_deployer.yml
+
+- hosts:
+    - shc
+  roles:
+    - ../roles/splunk
+  vars:
+    - deployment_task: check_splunk.yml
+
+- hosts:
+    - shc
+  roles:
+    - ../roles/splunk
+  vars:
+    - deployment_task: configure_shc_members.yml
+
+- hosts:
+    - shc
+  roles:
+    - ../roles/splunk
+  vars:
+    - deployment_task: configure_shc_captain.yml

--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # defaults file for splunk role
 # Anything that is undefined here should be configured. I recommend setting the values in your group_vars under an all.yml file.
+systemd_boot: false # Do NOT change the value of this. It automatically gets changed in main.yml if the role finds an existing systemd file configured for splunk.
 slack_channel: undefined
 slack_token: undefined
 splunk_home: auto_determined # This gets set by main.yml but we have to define it here or Ansible will complain that it is undefined
@@ -31,6 +32,16 @@ git_key: undefined # Path to SSH key for cloning repositories - Note that this m
 git_project: undefined
 git_version: master # Configure default version to clone, overridable inside the git_apps dictionary within host_vars
 splunk_app_deploy_path: undefined # Path under $SPLUNK_HOME/ to deploy apps to - Note that this may be set in group_vars, host_vars, playbook vars, or inside the git_apps dictionary within host_vars
+# SHC Vars
+splunk_shc_key: mypass4symmkey
+splunk_shc_label: myshc
+splunk_shc_rf: 3
+splunk_shc_rep_port: 8100
+splunk_shc_target_group: shc
+splunkd_port: 8089
+splunk_shc_deployer: "{{ groups['shdeployer'] | first }}" # If you manage multiple SHCs, configure the var value in group_vars
+splunk_shc_uri_list: "{% for h in groups[splunk_shc_target_group] %}https://{{ hostvars[h].ansible_fqdn }}:{{ splunkd_port }}{% if not loop.last %},{% endif %}{% endfor %}" # If you manage multiple SHCs, configure the var value in group_vars
+# Linux and scripting related vars
 add_crashlog_script: false # Set to true to install a script and cron job to automatically cleanup splunk crash logs older than 7 days
 add_diag_script: false # Set to true to install a script and cron job to automatically cleanup splunk diag files older than 30 days
 add_pstack_script: false # Set to true to install a pstack generation script for troubleshooting purposes in $SPLUNK_HOLME/genpstacks.sh

--- a/roles/splunk/tasks/configure_shc_captain.yml
+++ b/roles/splunk/tasks/configure_shc_captain.yml
@@ -1,0 +1,7 @@
+---
+- name: Bring up cluster captain
+  command: "{{ splunk_home }}/bin/splunk bootstrap shcluster-captain -servers_list {{ splunk_shc_uri_list }} -auth {{ splunk_auth }}"
+  become: yes
+  become_user: "{{ splunk_nix_user }}"
+  run_once: true
+  no_log: true

--- a/roles/splunk/tasks/configure_shc_deployer.yml
+++ b/roles/splunk/tasks/configure_shc_deployer.yml
@@ -1,0 +1,13 @@
+---
+- name: Configure shclustering stanza for deployer
+  ini_file:
+    path: "{{ splunk_home }}/etc/system/local/server.conf"
+    section: shclustering
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+  become: yes
+  become_user: "{{ splunk_nix_user }}"
+  notify: restart splunk
+  loop:
+    - { option: "pass4SymmKey", value: "{{ splunk_shc_key }}" }
+    - { option: "shcluster_label", value: "{{ splunk_shc_label }}" }

--- a/roles/splunk/tasks/configure_shc_members.yml
+++ b/roles/splunk/tasks/configure_shc_members.yml
@@ -1,0 +1,7 @@
+---
+- name: Initialize shc config
+  command: "{{ splunk_home }}/bin/splunk init shcluster-config -auth {{ splunk_auth }} -mgmt_uri https://{{ ansible_fqdn }}:{{ splunkd_port }} -replication_port {{ splunk_shc_rep_port }} -replication_factor {{ splunk_shc_rf }} -conf_deploy_fetch_url https://{{ splunk_shc_deployer }}:{{ splunkd_port }} -secret {{ splunk_shc_key }} -shcluster_label {{ splunk_shc_label }}"
+  become: yes
+  become_user: "{{ splunk_nix_user }}"
+  notify: restart splunk
+  no_log: true 

--- a/roles/splunk/tasks/configure_splunk_boot.yml
+++ b/roles/splunk/tasks/configure_splunk_boot.yml
@@ -1,69 +1,73 @@
 ---
 # Note: Splunk must be stopped when creating or altering systemd related configurations for it
-- name: Check if Splunk needs to be stopped if boot-start isn't configured as Ansible expects (or boot-start is not configured at all)
-  command: "{{ splunk_home }}/bin/splunk status"
-  register: splunk_status
-  become: yes
-  become_user: "{{ splunk_nix_user }}"
-  changed_when: false
-  failed_when: false
-  when: >
-    (systemd_boot.stat.exists and splunk_use_initd) or
-    (initd_boot.stat.exists and not splunk_use_initd) or
-    (not systemd_boot.stat.exists and not initd_boot.stat.exists and not splunk_use_initd)
-
-- name: Block to stop splunk when systemd was detected but init.d is configured in Ansible
+- name: Block for checking boot-start when an existing Splunk installation has been found
   block:
-    - name: Stop Splunkd via systemd service name to prepare for conversion to init.d
-      service:
-        name: Splunkd
-        state: stopped
-      become: yes
-      when:
-        - "'full' in group_names"
+    
+  - name: Check if Splunk needs to be stopped if boot-start isn't configured as Ansible expects (or boot-start is not configured at all)
+    command: "{{ splunk_home }}/bin/splunk status"
+    register: splunk_status
+    become: yes
+    become_user: "{{ splunk_nix_user }}"
+    changed_when: false
+    failed_when: false
+    when: >
+      ((systemd_boot and splunk_use_initd) or
+      (initd_boot.stat.exists and not splunk_use_initd) or
+      (not systemd_boot and not initd_boot.stat.exists and not splunk_use_initd))
 
-    - name: Stop SplunkForwarder via systemd service name to prepare for conversion to init.d
-      service:
-        name: SplunkForwarder
-        state: stopped
-      become: yes
-      when:
-        - "'uf' in group_names"
-  when:
-    - systemd_boot.stat.exists and splunk_use_initd
-    - splunk_status.stdout != 'splunkd is not running.'
+  - name: Block to stop splunk when systemd was detected but init.d is configured in Ansible
+    block:
+      - name: Stop Splunkd via systemd service name to prepare for conversion to init.d
+        service:
+          name: Splunkd
+          state: stopped
+        become: yes
+        when:
+          - "'full' in group_names"
 
-- name: Stop Splunk via init.d to prepare for conversion to systemd
-  service:
-    name: splunk
-    state: stopped
-  become: yes
-  when:
-    - initd_boot.stat.exists and not splunk_use_initd
-    - splunk_status.stdout != 'splunkd is not running.'
+      - name: Stop SplunkForwarder via systemd service name to prepare for conversion to init.d
+        service:
+          name: SplunkForwarder
+          state: stopped
+        become: yes
+        when:
+          - "'uf' in group_names"
+    when:
+      - systemd_boot and splunk_use_initd
+      - splunk_status.stdout != 'splunkd is not running.'
 
-- name: Stop Splunk via command if boot-start is not configured at all and systemd is configured in Ansible
-  command: "{{ splunk_home }}/bin/splunk stop"
-  become: yes
-  when:
-    - not systemd_boot.stat.exists
-    - not initd_boot.stat.exists
-    - not splunk_use_initd
-    - splunk_status.stdout != 'splunkd is not running.'
+  - name: Stop Splunk via init.d to prepare for conversion to systemd
+    service:
+      name: splunk
+      state: stopped
+    become: yes
+    when:
+      - initd_boot.stat.exists and not splunk_use_initd
+      - splunk_status.stdout != 'splunkd is not running.'
 
-- name: Disable boot-start if current configuration does not matched expected configuration
-  shell: "{{ splunk_home }}/bin/splunk disable boot-start"
-  become: yes
-  when: >
-    (systemd_boot.stat.exists and splunk_use_initd) or
-    (initd_boot.stat.exists and not splunk_use_initd)
+  - name: Stop Splunk via command if boot-start is not configured at all and systemd is configured in Ansible
+    command: "{{ splunk_home }}/bin/splunk stop"
+    become: yes
+    when:
+      - not systemd_boot
+      - not initd_boot.stat.exists
+      - not splunk_use_initd
+      - splunk_status.stdout != 'splunkd is not running.'
+
+  - name: Disable boot-start if current configuration does not matched expected configuration
+    shell: "{{ splunk_home }}/bin/splunk disable boot-start"
+    become: yes
+    when: >
+      (systemd_boot and splunk_use_initd) or
+      (initd_boot.stat.exists and not splunk_use_initd)
+      
+  when: splunkd_found.stat.exists
 
 - name: Enable splunk boot-start via initd
   shell: "{{ splunk_home }}/bin/splunk enable boot-start -user {{ splunk_nix_user }} -systemd-managed 0 --answer-yes --auto-ports --no-prompt --accept-license"
   become: yes
-  when: 
-    - splunk_use_initd
-    - systemd_boot.stat.exists or not initd_boot.stat.exists
+  when:
+    - splunk_use_initd and not initd_boot.stat.exists 
   notify:
     - set ulimits in init.d
     - reload systemctl daemon
@@ -72,9 +76,8 @@
 - name: Enable splunk boot-start via systemd
   shell: "{{ splunk_home }}/bin/splunk enable boot-start -user {{ splunk_nix_user }} -systemd-managed 1 --answer-yes --auto-ports --no-prompt --accept-license"
   become: yes
-  when: 
-    - not splunk_use_initd
-    - initd_boot.stat.exists or not systemd_boot.stat.exists
+  when:
+    - not splunk_use_initd and not systemd_boot
   notify:
     - reload systemctl daemon
     - start splunk

--- a/roles/splunk/tasks/main.yml
+++ b/roles/splunk/tasks/main.yml
@@ -13,7 +13,7 @@
       stat:
         path: /etc/systemd/system/Splunkd.service
         follow: yes
-      register: systemd_boot
+      register: systemd_boot_full
       become: yes
   when: "'full' in group_names"
 
@@ -31,9 +31,14 @@
       stat:
         path: /etc/systemd/system/SplunkForwarder.service
         follow: yes
-      register: systemd_boot
+      register: systemd_boot_uf
       become: yes
   when: "'uf' in group_names"
+
+- name: Set systemd_boot var to true if systemd is being used for splunk
+  set_fact:
+    systemd_boot: true
+  when: (systemd_boot_uf.stat is defined and systemd_boot_uf.stat.exists) or (systemd_boot_full.stat is defined and systemd_boot_full.stat.exists) 
 
 - name: Check if current boot-start method is init.d
   stat:
@@ -57,7 +62,7 @@
       - "To correct this: Either run configure_splunk_boot.yml or update the value of splunk_use_initd in your group_vars."
   when:
     - splunkd_found.stat.exists
-    - (systemd_boot.stat.exists and splunk_use_initd) or (initd_boot.stat.exists and not splunk_use_initd) or (not systemd_boot.stat.exists and not initd_boot.stat.exists)
+    - (systemd_boot and splunk_use_initd) or (initd_boot.stat.exists and not splunk_use_initd) or (not systemd_boot and not initd_boot.stat.exists)
     - not deployment_task == "configure_splunk_boot.yml"
 
 - name: Configure var for splunk init.d service handler


### PR DESCRIPTION
* Fixed `error 'dict object' has no attribute 'stat'` related to systemd_boot.stat.exists conditionals caused by variable re-usage in a skipped task (because register is still evaluated even if the task is skipped)
* Added basic support for deploying a new search head cluster