### PR TITLE
Multiple updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ You may also override the auto-configured `splunk_app_deploy_path` at the reposi
 
 **Configure local splunk admin password at install**
 ```
-splunk_user_seed: true
 splunk_admin_username: youradminusername (optional, defaults to admin)
 splunk_admin_password: yourpassword
 ```

--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -19,7 +19,6 @@ splunk_uri_ds: undefined # e.g. mydeploymentserver.mydomain.com:8089 ; Note that
 clientName: undefined
 splunk_admin_username: admin
 splunk_admin_password: undefined # Use ansible-vault encrypt_string, e.g. ansible-vault encrypt_string --ask-vault-pass 'var_value_to_encrypt' --name 'var_name'
-splunk_user_seed: false # Requires splunk_admin_password var to be set
 splunk_configure_secret: false # If set to true, you need to update files/splunk.secret
 # Although there are tasks for the following Splunk configurations in this role, they are not included in any tasks by default. You can add them to your install_splunk.yml if you would like to have Ansible manage any of these files
 splunk_configure_authentication: false

--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -32,6 +32,10 @@ git_key: undefined # Path to SSH key for cloning repositories - Note that this m
 git_project: undefined
 git_version: master # Configure default version to clone, overridable inside the git_apps dictionary within host_vars
 splunk_app_deploy_path: undefined # Path under $SPLUNK_HOME/ to deploy apps to - Note that this may be set in group_vars, host_vars, playbook vars, or inside the git_apps dictionary within host_vars
+splunk_apply_cluster_bundle_retries: 3 # How many times to retry indexer cluster bundle apply if it fails
+splunk_apply_cluster_bundle_delay: 60 # Delay in seconds between retries to apply indexer cluster bundle
+splunk_apply_shcluster_bundle_retries: 3 # How many times to retry SHC bundle apply if it fails
+splunk_apply_shcluster_bundle_delay: 60 #  Delay in seconds between retries to apply SHC bundle
 # SHC Vars
 splunk_shc_key: mypass4symmkey
 splunk_shc_label: myshc

--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -20,6 +20,7 @@ clientName: undefined
 splunk_admin_username: admin
 splunk_admin_password: undefined # Use ansible-vault encrypt_string, e.g. ansible-vault encrypt_string --ask-vault-pass 'var_value_to_encrypt' --name 'var_name'
 splunk_configure_secret: false # If set to true, you need to update files/splunk.secret
+splunk_secret_file: splunk.secret # Used to specify your splunk.secret filename(s), files should be placed in the "files" folder of the role
 # Although there are tasks for the following Splunk configurations in this role, they are not included in any tasks by default. You can add them to your install_splunk.yml if you would like to have Ansible manage any of these files
 splunk_configure_authentication: false
 ad_bind_password: undefined # Use ansible-vault encrypt_string, e.g. ansible-vault encrypt_string --ask-vault-pass 'var_value_to_encrypt' --name 'var_name'

--- a/roles/splunk/handlers/main.yml
+++ b/roles/splunk/handlers/main.yml
@@ -41,9 +41,14 @@
   become: yes
 
 - name: apply indexer cluster bundle
-  shell: "{{ splunk_home }}/bin/splunk apply cluster-bundle --answer-yes --skip-validation -auth {{ splunk_auth }}"
+  command: "{{ splunk_home }}/bin/splunk apply cluster-bundle --answer-yes --skip-validation -auth {{ splunk_auth }}"
   become: yes
   become_user: "{{ splunk_nix_user }}"
+  register: apply_cluster_bundle_result
+  changed_when: apply_cluster_bundle_result.rc == 0
+  failed_when: apply_cluster_bundle_result.rc != 0
+  retries: "{{ splunk_apply_cluster_bundle_retries }}"
+  delay: "{{ splunk_apply_cluster_bundle_delay }}"
   no_log: true
   when: "'clustermaster' in group_names"
 
@@ -55,9 +60,14 @@
   when: "'deploymentserver' in group_names"
 
 - name: apply shcluster-bundle
-  shell: "{{ splunk_home }}/bin/splunk apply shcluster-bundle -preserve-lookups true --answer-yes -auth {{ splunk_auth }} -target {{ deploy_target }}"
+  command: "{{ splunk_home }}/bin/splunk apply shcluster-bundle -preserve-lookups true --answer-yes -auth {{ splunk_auth }} -target {{ deploy_target }}"
   become: yes
   become_user: "{{ splunk_nix_user }}"
+  register: apply_shcluster_bundle_result
+  changed_when: apply_shcluster_bundle_result.rc == 0
+  failed_when: apply_shcluster_bundle_result.rc != 0 
+  retries: "{{ splunk_apply_shcluster_bundle_retries }}"
+  delay: "{{ splunk_apply_shcluster_bundle_delay }}"
   no_log: true
   when: "'shdeployer' in group_names and deploy_target is defined"
 

--- a/roles/splunk/tasks/check_splunk.yml
+++ b/roles/splunk/tasks/check_splunk.yml
@@ -17,7 +17,7 @@
 
 - name: Execute this block only if splunk is already installed
   block:
- # If Splunk is installed, get the current version
+
   - name: Run splunk version command to check currently installed version
     shell: "{{ splunk_home }}/bin/splunk version --answer-yes --auto-ports --no-prompt --accept-license"
     register: current_version
@@ -29,26 +29,23 @@
     debug:
       msg: "The value of splunk_version is: {{ splunk_version }} and the current_version is: {{ current_version.stdout }}"
 
-  - name: "Checkpoint: Package"
-    debug:
-      msg: "We will download the latest release from {{ splunk_package_url }}"
-    when: current_version.stdout != splunk_version
+  - name: Execute this block only if the current version does not match the expected version
+    block:
+      - name: "Checkpoint: Package"
+        debug:
+          msg: "We will download the latest release from {{ splunk_package_url }}"
 
-  - name: Check if Splunk needs to be stopped if we are not at the expected version
-    shell: "{{ splunk_home }}/bin/splunk status"
-    register: splunk_status
-    become: yes
-    become_user: "{{ splunk_nix_user }}"
-    when: current_version.stdout != splunk_version
-    changed_when: false
-    ignore_errors: true
+      - name: Check if Splunk needs to be stopped if we are not at the expected version
+        include_tasks: check_splunk_status.yml
+        changed_when: false
 
-  - name: Stop Splunk if not at expected version and not currently stopped
-    include_tasks: splunk_stop.yml
-    when: current_version.stdout != splunk_version and splunk_status.stdout != 'splunkd is not running.'
+      - name: Stop Splunk if not at expected version and not currently stopped
+        include_tasks: splunk_stop.yml
+        when: splunk_status.rc != 0
 
-  - name: Upgrade Splunk if not at expected version
-    include_tasks: upgrade_splunk.yml
+      - name: Upgrade Splunk if not at expected version
+        include_tasks: upgrade_splunk.yml
+# Conditional for version mismatch block
     when: current_version.stdout != splunk_version
 # Conditional for this block
   when: splunkd_path.stat.exists == true

--- a/roles/splunk/tasks/check_splunk.yml
+++ b/roles/splunk/tasks/check_splunk.yml
@@ -18,34 +18,34 @@
 - name: Execute this block only if splunk is already installed
   block:
 
-  - name: Run splunk version command to check currently installed version
-    shell: "{{ splunk_home }}/bin/splunk version --answer-yes --auto-ports --no-prompt --accept-license"
-    register: current_version
-    become: yes
-    become_user: "{{ splunk_nix_user }}"
-    changed_when: false
+    - name: Run splunk version command to check currently installed version
+      shell: "{{ splunk_home }}/bin/splunk version --answer-yes --auto-ports --no-prompt --accept-license"
+      register: current_version
+      become: yes
+      become_user: "{{ splunk_nix_user }}"
+      changed_when: false
 
-  - name: "Checkpoint: Version" ##########################
-    debug:
-      msg: "The value of splunk_version is: {{ splunk_version }} and the current_version is: {{ current_version.stdout }}"
+    - name: "Checkpoint: Version" ##########################
+      debug:
+        msg: "The value of splunk_version is: {{ splunk_version }} and the current_version is: {{ current_version.stdout }}"
 
-  - name: Execute this block only if the current version does not match the expected version
-    block:
-      - name: "Checkpoint: Package"
-        debug:
-          msg: "We will download the latest release from {{ splunk_package_url }}"
+    - name: Execute this block only if the current version does not match the expected version
+      block:
+        - name: "Checkpoint: Package"
+          debug:
+            msg: "We will download the latest release from {{ splunk_package_url }}"
 
-      - name: Check if Splunk needs to be stopped if we are not at the expected version
-        include_tasks: check_splunk_status.yml
-        changed_when: false
+        - name: Check if Splunk needs to be stopped if we are not at the expected version
+          include_tasks: check_splunk_status.yml
+          changed_when: false
 
-      - name: Stop Splunk if not at expected version and splunk is currently running
-        include_tasks: splunk_stop.yml
-        when: splunk_status.rc == 0
+        - name: Stop Splunk if not at expected version and splunk is currently running
+          include_tasks: splunk_stop.yml
+          when: splunk_status.rc == 0
 
-      - name: Upgrade Splunk if not at expected version
-        include_tasks: upgrade_splunk.yml
+        - name: Upgrade Splunk if not at expected version
+          include_tasks: upgrade_splunk.yml
 # Conditional for version mismatch block
-    when: current_version.stdout != splunk_version
+      when: current_version.stdout != splunk_version
 # Conditional for this block
   when: splunkd_path.stat.exists == true

--- a/roles/splunk/tasks/check_splunk.yml
+++ b/roles/splunk/tasks/check_splunk.yml
@@ -39,9 +39,9 @@
         include_tasks: check_splunk_status.yml
         changed_when: false
 
-      - name: Stop Splunk if not at expected version and not currently stopped
+      - name: Stop Splunk if not at expected version and splunk is currently running
         include_tasks: splunk_stop.yml
-        when: splunk_status.rc != 0
+        when: splunk_status.rc == 0
 
       - name: Upgrade Splunk if not at expected version
         include_tasks: upgrade_splunk.yml

--- a/roles/splunk/tasks/check_splunk_status.yml
+++ b/roles/splunk/tasks/check_splunk_status.yml
@@ -1,0 +1,7 @@
+---
+- name: Check if Splunk is currently running or stopped
+  command: "{{ splunk_home }}/bin/splunk status"
+  register: splunk_status
+  become: yes
+  become_user: "{{ splunk_nix_user }}"
+  changed_when: false

--- a/roles/splunk/tasks/configure_splunk_boot.yml
+++ b/roles/splunk/tasks/configure_splunk_boot.yml
@@ -4,12 +4,8 @@
   block:
     
   - name: Check if Splunk needs to be stopped if boot-start isn't configured as Ansible expects (or boot-start is not configured at all)
-    command: "{{ splunk_home }}/bin/splunk status"
-    register: splunk_status
-    become: yes
-    become_user: "{{ splunk_nix_user }}"
+    include_tasks: check_splunk_status.yml
     changed_when: false
-    failed_when: false
     when: >
       ((systemd_boot and splunk_use_initd) or
       (initd_boot.stat.exists and not splunk_use_initd) or
@@ -34,7 +30,7 @@
           - "'uf' in group_names"
     when:
       - systemd_boot and splunk_use_initd
-      - splunk_status.stdout != 'splunkd is not running.'
+      - splunk_status.rc != 0
 
   - name: Stop Splunk via init.d to prepare for conversion to systemd
     service:
@@ -43,7 +39,7 @@
     become: yes
     when:
       - initd_boot.stat.exists and not splunk_use_initd
-      - splunk_status.stdout != 'splunkd is not running.'
+      - splunk_status.rc != 0
 
   - name: Stop Splunk via command if boot-start is not configured at all and systemd is configured in Ansible
     command: "{{ splunk_home }}/bin/splunk stop"
@@ -52,7 +48,7 @@
       - not systemd_boot
       - not initd_boot.stat.exists
       - not splunk_use_initd
-      - splunk_status.stdout != 'splunkd is not running.'
+      - splunk_status.rc != 0
 
   - name: Disable boot-start if current configuration does not matched expected configuration
     shell: "{{ splunk_home }}/bin/splunk disable boot-start"

--- a/roles/splunk/tasks/configure_splunk_boot.yml
+++ b/roles/splunk/tasks/configure_splunk_boot.yml
@@ -30,7 +30,7 @@
           - "'uf' in group_names"
     when:
       - systemd_boot and splunk_use_initd
-      - splunk_status.rc != 0
+      - splunk_status.rc == 0
 
   - name: Stop Splunk via init.d to prepare for conversion to systemd
     service:
@@ -39,7 +39,7 @@
     become: yes
     when:
       - initd_boot.stat.exists and not splunk_use_initd
-      - splunk_status.rc != 0
+      - splunk_status.rc == 0
 
   - name: Stop Splunk via command if boot-start is not configured at all and systemd is configured in Ansible
     command: "{{ splunk_home }}/bin/splunk stop"
@@ -48,7 +48,7 @@
       - not systemd_boot
       - not initd_boot.stat.exists
       - not splunk_use_initd
-      - splunk_status.rc != 0
+      - splunk_status.rc == 0
 
   - name: Disable boot-start if current configuration does not matched expected configuration
     shell: "{{ splunk_home }}/bin/splunk disable boot-start"

--- a/roles/splunk/tasks/configure_splunk_secret.yml
+++ b/roles/splunk/tasks/configure_splunk_secret.yml
@@ -1,6 +1,6 @@
 - name: Install splunk.secret
   copy:
-    src: splunk.secret
+    src: "{{ splunk_secret_file }}"
     dest: "{{ splunk_home }}/etc/auth/splunk.secret"
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"

--- a/roles/splunk/tasks/configure_user-seed.yml
+++ b/roles/splunk/tasks/configure_user-seed.yml
@@ -12,7 +12,6 @@
     dest: "{{ splunk_home }}/etc/system/local/user-seed.conf"
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
-  notify: restart splunk
   become: yes
   when:
     - not splunk_etc_passwd.stat.exists

--- a/roles/splunk/tasks/configure_user-seed.yml
+++ b/roles/splunk/tasks/configure_user-seed.yml
@@ -1,18 +1,20 @@
 ---
-- name: "Check for existing {{ splunk_home }}/etc/passwd"
-  stat:
-    path: "{{ splunk_home }}/etc/passwd"
-  register: splunk_etc_passwd
-  become: yes
-  become_user: "{{ splunk_nix_user }}"
+- name: Execute this block only when splunk_admin_password has been configured
+  block:
+    - name: "Check for existing {{ splunk_home }}/etc/passwd"
+      stat:
+        path: "{{ splunk_home }}/etc/passwd"
+      register: splunk_etc_passwd
+      become: yes
+      become_user: "{{ splunk_nix_user }}"
 
-- name: Create user-seed.conf file with splunk_admin_username and splunk_admin_password
-  template:
-    src: user-seed.conf.j2
-    dest: "{{ splunk_home }}/etc/system/local/user-seed.conf"
-    owner: "{{ splunk_nix_user }}"
-    group: "{{ splunk_nix_group }}"
-  become: yes
+    - name: Create user-seed.conf file with splunk_admin_username and splunk_admin_password
+      template:
+        src: user-seed.conf.j2
+        dest: "{{ splunk_home }}/etc/system/local/user-seed.conf"
+        owner: "{{ splunk_nix_user }}"
+        group: "{{ splunk_nix_group }}"
+      become: yes
+      when: not splunk_etc_passwd.stat.exists
   when:
-    - not splunk_etc_passwd.stat.exists
     - splunk_admin_password != 'undefined'

--- a/roles/splunk/tasks/configure_user-seed.yml
+++ b/roles/splunk/tasks/configure_user-seed.yml
@@ -16,5 +16,4 @@
   become: yes
   when:
     - not splunk_etc_passwd.stat.exists
-    - splunk_user_seed
     - splunk_admin_password != 'undefined'

--- a/roles/splunk/tasks/install_splunk.yml
+++ b/roles/splunk/tasks/install_splunk.yml
@@ -44,7 +44,6 @@
 - name: Include configure user-seed task
   include_tasks: configure_user-seed.yml
   when: 
-    - splunk_user_seed
     - splunk_admin_password != 'undefined'
 
 - name: Include configure default authentication.conf for AD authentication and admin role mapping

--- a/roles/splunk/tasks/remove_splunk.yml
+++ b/roles/splunk/tasks/remove_splunk.yml
@@ -1,0 +1,14 @@
+---
+- include_tasks: splunk_stop.yml
+
+- name: Disable boot-start
+  shell: "{{ splunk_home }}/bin/splunk disable boot-start"
+  become: yes
+
+- name: Remove splunk folder
+  file:
+    path: "{{ splunk_home }}"
+    state: absent
+  become: yes
+
+# Todo: Remove user, group, THP/ulimit files, check for cron jobs/scripts and remove those if present


### PR DESCRIPTION
**Bugfixes**
- Resolves https://github.com/splunk/ansible-role-for-splunk/issues/23
- Resolves https://github.com/splunk/ansible-role-for-splunk/issues/28

**Enhancements**
- Implements https://github.com/splunk/ansible-role-for-splunk/issues/24
- Implements https://github.com/splunk/ansible-role-for-splunk/issues/26
- Added 3 automatic retries with 1-minute retry delay for both shc and indexer cluster bundle pushes (configurable via vars)
- Adds very basic support for removing a Splunk installation (will be enhanced further in a future release)
- Removed redundant variable for `configure_user_seed` - the role will now automatically run this task during new installations as long as `splunk_admin_password` has been changed from the default value of `undefined`

**Miscellaneous**
- Removed redundant code via `include_tasks` and `block`