### PR TITLE
Fixed most linting warnings and a bug that was encountered when running Ansible against a host that has Splunk in a stopped state

### DIFF
--- a/roles/splunk/handlers/main.yml
+++ b/roles/splunk/handlers/main.yml
@@ -11,7 +11,7 @@
   loop:
     - ulimit -Hn 65536
     - ulimit -Sn 32768
-  become: yes
+  become: true
   ignore_errors: true
   when: splunk_use_initd and ansible_os_family == "RedHat" and ansible_distribution_major_version|int > 6
 
@@ -20,29 +20,29 @@
     path: /etc/init.d/splunk
     regexp: '(start --no-prompt --answer-yes)$'
     replace: '\1 --accept-license'
-  become: yes
+  become: true
   when: splunk_use_initd
 
 - name: reload systemctl daemon
   systemd:
-    daemon_reload: yes
-  become: yes
+    daemon_reload: true
+  become: true
 
 - name: stop splunk
   service:
     name: "{{ splunk_service }}"
     state: stopped
-  become: yes
+  become: true
 
 - name: start splunk
   service:
     name: "{{ splunk_service }}"
     state: started
-  become: yes
+  become: true
 
 - name: apply indexer cluster bundle
   command: "{{ splunk_home }}/bin/splunk apply cluster-bundle --answer-yes --skip-validation -auth {{ splunk_auth }}"
-  become: yes
+  become: true
   become_user: "{{ splunk_nix_user }}"
   register: apply_cluster_bundle_result
   changed_when: apply_cluster_bundle_result.rc == 0
@@ -53,15 +53,15 @@
   when: "'clustermaster' in group_names"
 
 - name: reload deployment server
-  shell: "{{ splunk_home }}/bin/splunk reload deploy-server -auth {{ splunk_auth }}"
-  become: yes
+  command: "{{ splunk_home }}/bin/splunk reload deploy-server -auth {{ splunk_auth }}"
+  become: true
   become_user: "{{ splunk_nix_user }}"
   no_log: true
   when: "'deploymentserver' in group_names"
 
 - name: apply shcluster-bundle
   command: "{{ splunk_home }}/bin/splunk apply shcluster-bundle -preserve-lookups true --answer-yes -auth {{ splunk_auth }} -target {{ deploy_target }}"
-  become: yes
+  become: true
   become_user: "{{ splunk_nix_user }}"
   register: apply_shcluster_bundle_result
   changed_when: apply_shcluster_bundle_result.rc == 0
@@ -75,9 +75,8 @@
   service:
     name: "{{ splunk_service }}"
     state: restarted
-  become: yes
+  become: true
 
 - name: restart auditd service
   command: service auditd condrestart
-  become: yes
-
+  become: true

--- a/roles/splunk/tasks/add_crashlog_script.yml
+++ b/roles/splunk/tasks/add_crashlog_script.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0755
-  become: yes
+  become: true
 
 - name: Configure cron to run cleanup_crashlogs.sh daily at midnight
   cron:
@@ -15,4 +15,4 @@
     job: "{{ splunk_home }}/cleanup_crashlogs.sh"
     hour: 0
     minute: 0
-  become: yes
+  become: true

--- a/roles/splunk/tasks/add_diag_script.yml
+++ b/roles/splunk/tasks/add_diag_script.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0755
-  become: yes
+  become: true
 
 - name: Configure cron to run cleanup_diags.sh daily at midnight
   cron:
@@ -15,4 +15,4 @@
     job: "{{ splunk_home }}/cleanup_diags.sh"
     hour: 0
     minute: 0
-  become: yes
+  become: true

--- a/roles/splunk/tasks/add_pstack_script.yml
+++ b/roles/splunk/tasks/add_pstack_script.yml
@@ -6,4 +6,4 @@
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
     mode: 0755
-  become: yes
+  become: true

--- a/roles/splunk/tasks/adhoc_clean_dispatch.yml
+++ b/roles/splunk/tasks/adhoc_clean_dispatch.yml
@@ -3,8 +3,8 @@
   include_tasks: splunk_stop.yml
 
 - name: Clean dispatch directory of all files
-  shell: "rm -rf {{ splunk_home }}/var/run/splunk/dispatch/*"
-  become: yes
+  command: "rm -rf {{ splunk_home }}/var/run/splunk/dispatch/*"
+  become: true
 
 - name: Start Splunk
   include_tasks: splunk_start.yml

--- a/roles/splunk/tasks/adhoc_configure_hostname.yml
+++ b/roles/splunk/tasks/adhoc_configure_hostname.yml
@@ -2,7 +2,7 @@
 - name: Set the system's hostname to the inventory_hostname
   hostname:
     name: "{{ inventory_hostname }}"
-  become: yes
+  become: true
 
 - name: "Update serverName in {{ splunk_home }}/etc/system/local/server.conf"
   lineinfile:
@@ -10,7 +10,7 @@
     state: present
     regexp: "^serverName = .*"
     line: "serverName = {{ ansible_hostname }}"
-  become: yes
+  become: true
   become_user: "{{ splunk_nix_user }}"
   notify: restart splunk
 
@@ -20,6 +20,6 @@
     state: present
     regexp: "^host = .*"
     line: "host = {{ ansible_hostname }}"
-  become: yes
+  become: true
   become_user: "{{ splunk_nix_user }}"
   notify: restart splunk

--- a/roles/splunk/tasks/adhoc_decom_indexer.yml
+++ b/roles/splunk/tasks/adhoc_decom_indexer.yml
@@ -1,7 +1,7 @@
 ---
 - name: Execute splunk offline --enforce-counts
-  shell: "{{ splunk_home }}/bin/splunk offline --enforce-counts -auth {{ splunk_auth }}"
-  become: yes
+  command: "{{ splunk_home }}/bin/splunk offline --enforce-counts -auth {{ splunk_auth }}"
+  become: true
   become_user: "{{ splunk_nix_user }}"
   no_log: true
   when: "'indexer' in group_names"

--- a/roles/splunk/tasks/adhoc_fix_mongo.yml
+++ b/roles/splunk/tasks/adhoc_fix_mongo.yml
@@ -6,22 +6,22 @@
     mode: 0600
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
-  become: yes
+  become: true
 
 - name: Delete mongod.lock if present
   file:
     state: absent
     path: "{{ splunk_home }}/var/lib/splunk/kvstore/mongo/mongod.lock"
-  become: yes
+  become: true
 
 - name: Update file permissions for journal
   file:
     state: directory
-    recurse: yes
+    recurse: true
     path: "{{ splunk_home }}/var/lib/splunk/kvstore/mongo/journal"
     mode: 0710
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
-  become: yes
+  become: true
 
 # Also consider adhoc_fix_server_certificate.yml if the cert is expired and you are using the default cert for kvstore

--- a/roles/splunk/tasks/adhoc_fix_server_certificate.yml
+++ b/roles/splunk/tasks/adhoc_fix_server_certificate.yml
@@ -2,8 +2,8 @@
 # To check if cert is expired:  splunk cmd openssl x509 -in /opt/splunk/etc/auth/server.pem -text -noout
 # Note: Genereates new default certificate. Do not use this if you generate/sign your own splunkd certificate
 - name: Remove old server.pem certificate and generate a new one
-  shell: "{{ item }}"
-  become: yes
+  command: "{{ item }}"
+  become: true
   become_user: "{{ splunk_nix_user }}"
   loop:
     - "rm {{ splunk_home }}/etc/auth/server.pem"

--- a/roles/splunk/tasks/adhoc_kill_splunkd.yml
+++ b/roles/splunk/tasks/adhoc_kill_splunkd.yml
@@ -1,4 +1,4 @@
 ---
 - name: Kill any stale splunkd processes
   shell: for i in $(ps -ef | grep splunkd -i | grep -v grep | awk '{print $2}'); do kill -9 $i; done
-  become: yes
+  become: true

--- a/roles/splunk/tasks/check_splunk.yml
+++ b/roles/splunk/tasks/check_splunk.yml
@@ -2,16 +2,16 @@
 - name: Check if Splunk is installed
   stat:
     path: "{{ splunk_home }}/bin/splunk"
-    follow: yes
+    follow: true
   register: splunkd_path
-  become: yes
+  become: true
 
-# If installed, check version, if version is good, don't install but continue
+  # If installed, check version, if version is good, don't install but continue
 - name: Install Splunk if not installed
   include_tasks: install_splunk.yml
   when: splunkd_path.stat.exists == false
 
-# Configure the license for both fresh and old installs
+  # Configure the license for both fresh and old installs
 - name: Configure license
   include_tasks: configure_license.yml
 
@@ -19,9 +19,9 @@
   block:
 
     - name: Run splunk version command to check currently installed version
-      shell: "{{ splunk_home }}/bin/splunk version --answer-yes --auto-ports --no-prompt --accept-license"
+      command: "{{ splunk_home }}/bin/splunk version --answer-yes --auto-ports --no-prompt --accept-license"
       register: current_version
-      become: yes
+      become: true
       become_user: "{{ splunk_nix_user }}"
       changed_when: false
 
@@ -45,7 +45,7 @@
 
         - name: Upgrade Splunk if not at expected version
           include_tasks: upgrade_splunk.yml
-# Conditional for version mismatch block
+      # Conditional for version mismatch block
       when: current_version.stdout != splunk_version
-# Conditional for this block
+  # Conditional for this block
   when: splunkd_path.stat.exists == true

--- a/roles/splunk/tasks/check_splunk_status.yml
+++ b/roles/splunk/tasks/check_splunk_status.yml
@@ -2,6 +2,6 @@
 - name: Check if Splunk is currently running or stopped
   command: "{{ splunk_home }}/bin/splunk status"
   register: splunk_status
-  become: yes
+  become: true
   become_user: "{{ splunk_nix_user }}"
   changed_when: false

--- a/roles/splunk/tasks/check_splunk_status.yml
+++ b/roles/splunk/tasks/check_splunk_status.yml
@@ -4,4 +4,5 @@
   register: splunk_status
   become: true
   become_user: "{{ splunk_nix_user }}"
+  failed_when: false
   changed_when: false

--- a/roles/splunk/tasks/configure_apps.yml
+++ b/roles/splunk/tasks/configure_apps.yml
@@ -1,5 +1,5 @@
 ---
-# Configure default splunk_app_deploy_path based on which group the host is a member of
+  # Configure default splunk_app_deploy_path based on which group the host is a member of
 - name: Set default splunk_app_deploy_path for clustermaster hosts
   set_fact:
     splunk_app_deploy_path: etc/master-apps
@@ -23,69 +23,69 @@
     - "'shdeployer' not in group_names"
     - "'deploymentserver' not in group_names"
 
-# Prep the Ansible host to deploy apps then install them
+  # Prep the Ansible host to deploy apps then install them
 - block:
-  - name: Create local directory for managing repos on the target host
-    file:
-      path: "{{ git_local_clone_path }}{{ ansible_nodename }}"
-      state: directory
-    delegate_to: localhost
-    changed_when: false
+    - name: Create local directory for managing repos on the target host
+      file:
+        path: "{{ git_local_clone_path }}{{ ansible_nodename }}"
+        state: directory
+      delegate_to: localhost
+      changed_when: false
 
-  - name: Install .rsync-filter to avoid copying undesirable files and folders to the target host later
-    copy:
-      src: rsync-filter
-      dest: "{{ git_local_clone_path }}{{ ansible_nodename }}/.rsync-filter"
-    delegate_to: localhost
-    changed_when: false
+    - name: Install .rsync-filter to avoid copying undesirable files and folders to the target host later
+      copy:
+        src: rsync-filter
+        dest: "{{ git_local_clone_path }}{{ ansible_nodename }}/.rsync-filter"
+      delegate_to: localhost
+      changed_when: false
 
-  - name: Download defined Git repos to local Ansible host
-    local_action:
-                  module: git
-                  accept_hostkey: yes
-                  repo: "{{ item.git_server | default(git_server) }}/{{ item.git_project | default(git_project) }}/{{ item.name }}"
-                  version: "{{ item.git_version | default(git_version) }}"
-                  dest: "{{ git_local_clone_path }}{{ ansible_nodename }}/{{ item.name }}"
-                  key_file: "{{ git_key }}"
-                  force: yes
-    loop: "{{ git_apps }}"
-    changed_when: false
-    check_mode: no
+    - name: Download defined Git repos to local Ansible host
+      git:
+        accept_hostkey: true
+        repo: "{{ item.git_server | default(git_server) }}/{{ item.git_project | default(git_project) }}/{{ item.name }}"
+        version: "{{ item.git_version | default(git_version) }}"
+        dest: "{{ git_local_clone_path }}{{ ansible_nodename }}/{{ item.name }}"
+        key_file: "{{ git_key }}"
+        force: true
+      loop: "{{ git_apps }}"
+      delegate_to: localhost
+      changed_when: false
+      check_mode: false
 
-  - name: Ensure rsync is installed on target host
-    package:
-      name: rsync
-      state: present
-      update_cache: true
-    become: yes
+    - name: Ensure rsync is installed on target host
+      package:
+        name: rsync
+        state: present
+        update_cache: true
+      become: true
 
-  - name: "Comment out requiretty in sudoers as it causes synchronize to fail on target host"
-    lineinfile:
-           dest: "/etc/sudoers"
-           state: present
-           regexp: "^#?{{ item }}"
-           line: "#{{ item }}"
-           create: yes
-           owner: root
-           group: root
-           mode: 0440
-    loop:
-      - "Defaults    requiretty"
-    become: yes
+    - name: "Comment out requiretty in sudoers as it causes synchronize to fail on target host"
+      lineinfile:
+        dest: "/etc/sudoers"
+        state: present
+        regexp: "^#?{{ item }}"
+        line: "#{{ item }}"
+        create: true
+        owner: root
+        group: root
+        mode: 0440
+      loop:
+        - "Defaults    requiretty"
+      become: true
 
-  - name: Install apps
-    include_tasks: install_apps.yml
-    loop: "{{ git_apps }}"
-    vars:
-      app_dest: "{{ item.splunk_app_deploy_path | default(splunk_app_deploy_path) }}"
-      app_src: "{{ git_local_clone_path }}{{ ansible_nodename }}/{{ item.name }}"
+    - name: Install apps
+      include_tasks: install_apps.yml
+      loop: "{{ git_apps }}"
+      vars:
+        app_dest: "{{ item.splunk_app_deploy_path | default(splunk_app_deploy_path) }}"
+        app_src: "{{ git_local_clone_path }}{{ ansible_nodename }}/{{ item.name }}"
 
-  - name: Cleanup the local directory that was used to manage repos on the target host
-    file:
-      path: "{{ git_local_clone_path }}{{ ansible_nodename }}"
-      state: absent
-    delegate_to: localhost
-    changed_when: false
+    - name: Cleanup the local directory that was used to manage repos on the target host
+      file:
+        path: "{{ git_local_clone_path }}{{ ansible_nodename }}"
+        state: absent
+      delegate_to: localhost
+      changed_when: false
 
   # Conditional for block
   when:

--- a/roles/splunk/tasks/configure_authentication.yml
+++ b/roles/splunk/tasks/configure_authentication.yml
@@ -5,7 +5,7 @@
     dest: "{{ splunk_home }}/etc/system/local/authentication.conf"
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
-  become: yes
+  become: true
   when:
     - splunk_authenticationconf is defined
     - ad_bind_password != 'undefined'

--- a/roles/splunk/tasks/configure_bash.yml
+++ b/roles/splunk/tasks/configure_bash.yml
@@ -1,11 +1,12 @@
 ---
 - name: Install .bashrc and .bash_profile files
   template:
-    src: "{{ item.bashtemplate}}"
+    src: "{{ item.bashtemplate }}"
     dest: "{{ splunk_home }}/{{ item.bashfilepath }}"
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
-  become: yes
+    mode: 0644
+  become: true
   loop:
     - { bashtemplate: 'bashrc.j2', bashfilepath: '.bashrc' }
     - { bashtemplate: 'bash_profile.j2', bashfilepath: '.bash_profile' }

--- a/roles/splunk/tasks/configure_deploymentclient.yml
+++ b/roles/splunk/tasks/configure_deploymentclient.yml
@@ -5,7 +5,7 @@
     dest: "{{ splunk_home }}/etc/system/local/deploymentclient.conf"
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
-  become: yes
+  become: true
   notify: restart splunk
   when:
     - clientName != 'undefined'

--- a/roles/splunk/tasks/configure_facl.yml
+++ b/roles/splunk/tasks/configure_facl.yml
@@ -1,43 +1,43 @@
 ---
 - name: Configure file access control list (facl) settings for splunk user
   block:
-  - name: Set default facl to allow splunk user to read /var/log
-    acl:
-      path: /var/log
-      entity: "{{ splunk_nix_user }}"
-      etype: user
-      permissions: rx
-      default: "{{ item }}"
-      recursive: yes
-      state: present
-    become: yes
-    loop:
-      - yes
-      - no
+    - name: Set default facl to allow splunk user to read /var/log
+      acl:
+        path: /var/log
+        entity: "{{ splunk_nix_user }}"
+        etype: user
+        permissions: rx
+        default: "{{ item }}"
+        recursive: true
+        state: present
+      become: true
+      loop:
+        - true
+        - false
 
-  - name: Add logrotate script to enforce splunk user facls
-    template:
-      src: splunk_facl.j2
-      dest: /etc/logrotate.d/splunk_facl
-      owner: root
-      group: root
-    become: yes
+    - name: Add logrotate script to enforce splunk user facls
+      template:
+        src: splunk_facl.j2
+        dest: /etc/logrotate.d/splunk_facl
+        owner: root
+        group: root
+      become: true
 
-  - name: Check if auditd.conf is present
-    stat:
-      path: /etc/audit/auditd.conf
-    register: result_auditd_conf
-    become: yes
+    - name: Check if auditd.conf is present
+      stat:
+        path: /etc/audit/auditd.conf
+      register: result_auditd_conf
+      become: true
 
-  - name: Allow splunk to read /var/log/audit.log
-    ini_file:
-      path: /etc/audit/auditd.conf
-      section: null
-      option: log_group
-      value: "{{ splunk_nix_group }}"
-    become: yes
-    notify: restart auditd service
-    ignore_errors: true
-    when: result_auditd_conf.stat.exists
+    - name: Allow splunk to read /var/log/audit.log
+      ini_file:
+        path: /etc/audit/auditd.conf
+        section: null
+        option: log_group
+        value: "{{ splunk_nix_group }}"
+      become: true
+      notify: restart auditd service
+      ignore_errors: true
+      when: result_auditd_conf.stat.exists
 
   when: splunk_nix_user != 'root'

--- a/roles/splunk/tasks/configure_initd.yml
+++ b/roles/splunk/tasks/configure_initd.yml
@@ -1,0 +1,7 @@
+---
+- name: "Add accept-license argument to splunk init.d"
+  replace:
+    path: /etc/init.d/splunk
+    regexp: '(start --no-prompt --answer-yes)$'
+    replace: '\1 --accept-license'
+  become: true

--- a/roles/splunk/tasks/configure_license.yml
+++ b/roles/splunk/tasks/configure_license.yml
@@ -7,7 +7,8 @@
     value: "{{ splunk_uri_lm }}"
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
-  become: yes
+    mode: 0644
+  become: true
   notify: restart splunk
   when:
     - "'full' in group_names"

--- a/roles/splunk/tasks/configure_os.yml
+++ b/roles/splunk/tasks/configure_os.yml
@@ -10,7 +10,7 @@
     owner: root
     group: root
     mode: 0644
-  become: yes
+  become: true
 
 - name: Disable THP
   include_tasks: configure_thp.yml

--- a/roles/splunk/tasks/configure_shc_captain.yml
+++ b/roles/splunk/tasks/configure_shc_captain.yml
@@ -1,7 +1,10 @@
 ---
 - name: Bring up cluster captain
   command: "{{ splunk_home }}/bin/splunk bootstrap shcluster-captain -servers_list {{ splunk_shc_uri_list }} -auth {{ splunk_auth }}"
-  become: yes
+  become: true
   become_user: "{{ splunk_nix_user }}"
+  register: shc_bootstrap_result
+  changed_when: shc_bootstrap_result.rc == 0
+  failed_when: shc_bootstrap_result.rc != 0
   run_once: true
   no_log: true

--- a/roles/splunk/tasks/configure_shc_deployer.yml
+++ b/roles/splunk/tasks/configure_shc_deployer.yml
@@ -5,8 +5,10 @@
     section: shclustering
     option: "{{ item.option }}"
     value: "{{ item.value }}"
-  become: yes
-  become_user: "{{ splunk_nix_user }}"
+    mode: 0644
+    owner: "{{ splunk_nix_user }}"
+    group: "{{ splunk_nix_group }}"
+  become: true
   notify: restart splunk
   loop:
     - { option: "pass4SymmKey", value: "{{ splunk_shc_key }}" }

--- a/roles/splunk/tasks/configure_shc_members.yml
+++ b/roles/splunk/tasks/configure_shc_members.yml
@@ -1,7 +1,10 @@
 ---
 - name: Initialize shc config
   command: "{{ splunk_home }}/bin/splunk init shcluster-config -auth {{ splunk_auth }} -mgmt_uri https://{{ ansible_fqdn }}:{{ splunkd_port }} -replication_port {{ splunk_shc_rep_port }} -replication_factor {{ splunk_shc_rf }} -conf_deploy_fetch_url https://{{ splunk_shc_deployer }}:{{ splunkd_port }} -secret {{ splunk_shc_key }} -shcluster_label {{ splunk_shc_label }}"
-  become: yes
+  become: true
   become_user: "{{ splunk_nix_user }}"
+  register: shc_init_result
+  changed_when: shc_init_result.rc == 0
+  failed_when: shc_init_result.rc != 0
   notify: restart splunk
   no_log: true 

--- a/roles/splunk/tasks/configure_splunk_boot.yml
+++ b/roles/splunk/tasks/configure_splunk_boot.yml
@@ -2,76 +2,80 @@
 # Note: Splunk must be stopped when creating or altering systemd related configurations for it
 - name: Block for checking boot-start when an existing Splunk installation has been found
   block:
-    
-  - name: Check if Splunk needs to be stopped if boot-start isn't configured as Ansible expects (or boot-start is not configured at all)
-    include_tasks: check_splunk_status.yml
-    changed_when: false
-    when: >
-      ((systemd_boot and splunk_use_initd) or
-      (initd_boot.stat.exists and not splunk_use_initd) or
-      (not systemd_boot and not initd_boot.stat.exists and not splunk_use_initd))
 
-  - name: Block to stop splunk when systemd was detected but init.d is configured in Ansible
-    block:
-      - name: Stop Splunkd via systemd service name to prepare for conversion to init.d
-        service:
-          name: Splunkd
-          state: stopped
-        become: yes
-        when:
-          - "'full' in group_names"
+    - name: Check if Splunk needs to be stopped if boot-start isn't configured as Ansible expects (or boot-start is not configured at all)
+      include_tasks: check_splunk_status.yml
+      changed_when: false
+      when: >
+        ((systemd_boot and splunk_use_initd) or
+        (initd_boot.stat.exists and not splunk_use_initd) or
+        (not systemd_boot and not initd_boot.stat.exists and not splunk_use_initd))
 
-      - name: Stop SplunkForwarder via systemd service name to prepare for conversion to init.d
-        service:
-          name: SplunkForwarder
-          state: stopped
-        become: yes
-        when:
-          - "'uf' in group_names"
-    when:
-      - systemd_boot and splunk_use_initd
-      - splunk_status.rc == 0
+    - name: Block to stop splunk when systemd was detected but init.d is configured in Ansible
+      block:
+        - name: Stop Splunkd via systemd service name to prepare for conversion to init.d
+          service:
+            name: Splunkd
+            state: stopped
+          become: true
+          when:
+            - "'full' in group_names"
 
-  - name: Stop Splunk via init.d to prepare for conversion to systemd
-    service:
-      name: splunk
-      state: stopped
-    become: yes
-    when:
-      - initd_boot.stat.exists and not splunk_use_initd
-      - splunk_status.rc == 0
+        - name: Stop SplunkForwarder via systemd service name to prepare for conversion to init.d
+          service:
+            name: SplunkForwarder
+            state: stopped
+          become: true
+          when:
+            - "'uf' in group_names"
 
-  - name: Stop Splunk via command if boot-start is not configured at all and systemd is configured in Ansible
-    command: "{{ splunk_home }}/bin/splunk stop"
-    become: yes
-    when:
-      - not systemd_boot
-      - not initd_boot.stat.exists
-      - not splunk_use_initd
-      - splunk_status.rc == 0
+      when:
+        - systemd_boot and splunk_use_initd
+        - splunk_status.rc == 0
 
-  - name: Disable boot-start if current configuration does not matched expected configuration
-    shell: "{{ splunk_home }}/bin/splunk disable boot-start"
-    become: yes
-    when: >
-      (systemd_boot and splunk_use_initd) or
-      (initd_boot.stat.exists and not splunk_use_initd)
-      
+    - name: Stop Splunk via init.d to prepare for conversion to systemd
+      service:
+        name: splunk
+        state: stopped
+      become: true
+      when:
+        - initd_boot.stat.exists and not splunk_use_initd
+        - splunk_status.rc == 0
+
+    - name: Stop Splunk via command if boot-start is not configured at all and systemd is configured in Ansible
+      command: "{{ splunk_home }}/bin/splunk stop"
+      register: splunk_stop_command_result
+      changed_when: splunk_stop_command_result.rc == 0
+      failed_when: splunk_stop_command_result.rc != 0
+      become: true
+      when:
+        - not systemd_boot
+        - not initd_boot.stat.exists
+        - not splunk_use_initd
+        - splunk_status.rc == 0
+
+    - name: Disable boot-start if current configuration does not matched expected configuration
+      command: "{{ splunk_home }}/bin/splunk disable boot-start"
+      become: true
+      when: >
+        (systemd_boot and splunk_use_initd) or
+        (initd_boot.stat.exists and not splunk_use_initd)
+
   when: splunkd_found.stat.exists
 
 - name: Enable splunk boot-start via initd
-  shell: "{{ splunk_home }}/bin/splunk enable boot-start -user {{ splunk_nix_user }} -systemd-managed 0 --answer-yes --auto-ports --no-prompt --accept-license"
-  become: yes
+  command: "{{ splunk_home }}/bin/splunk enable boot-start -user {{ splunk_nix_user }} -systemd-managed 0 --answer-yes --auto-ports --no-prompt --accept-license"
+  become: true
   when:
-    - splunk_use_initd and not initd_boot.stat.exists 
+    - splunk_use_initd and not initd_boot.stat.exists
   notify:
     - set ulimits in init.d
     - reload systemctl daemon
     - start splunk
 
 - name: Enable splunk boot-start via systemd
-  shell: "{{ splunk_home }}/bin/splunk enable boot-start -user {{ splunk_nix_user }} -systemd-managed 1 --answer-yes --auto-ports --no-prompt --accept-license"
-  become: yes
+  command: "{{ splunk_home }}/bin/splunk enable boot-start -user {{ splunk_nix_user }} -systemd-managed 1 --answer-yes --auto-ports --no-prompt --accept-license"
+  become: true
   when:
     - not splunk_use_initd and not systemd_boot
   notify:

--- a/roles/splunk/tasks/configure_splunk_forwarder_meta.yml
+++ b/roles/splunk/tasks/configure_splunk_forwarder_meta.yml
@@ -8,7 +8,8 @@
     value: splunk_forwarder_field
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
-  become: yes
+    mode: 0644
+  become: true
   notify: restart splunk
   when: "'full' in group_names"
 
@@ -20,7 +21,8 @@
     value: "{{ item.value }}"
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
-  become: yes
+    mode: 0644
+  become: true
   notify: restart splunk
   when: "'full' in group_names"
   loop:

--- a/roles/splunk/tasks/configure_splunk_secret.yml
+++ b/roles/splunk/tasks/configure_splunk_secret.yml
@@ -4,6 +4,7 @@
     dest: "{{ splunk_home }}/etc/auth/splunk.secret"
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
-  become: yes
+    mode: 0644
+  become: true
   notify: restart splunk
   when: splunk_configure_secret

--- a/roles/splunk/tasks/configure_systemd.yml
+++ b/roles/splunk/tasks/configure_systemd.yml
@@ -5,7 +5,8 @@
     section: Service
     option: "{{ item.option }}"
     value: "{{ item.value }}"
-  become: yes
+    mode: 0644
+  become: true
   loop:
     - { option: "ExecStart", value: "{{ splunk_home }}/bin/splunk start --accept-license --answer-yes --no-prompt" }
     - { option: "ExecStop", value: "{{ splunk_home }}/bin/splunk start stop" }

--- a/roles/splunk/tasks/configure_thp.yml
+++ b/roles/splunk/tasks/configure_thp.yml
@@ -7,10 +7,10 @@
   copy:
     src: disable-thp.service
     dest: /etc/systemd/system/disable-thp.service
-    mode: 0755
+    mode: 0644
     owner: root
     group: root
-  become: yes
+  become: true
   notify:
     - reload systemctl daemon
   # NOTE ansible_connection!="docker" is not included in the when expression
@@ -23,12 +23,12 @@
 - name: Disable THP service
   service:
     name: disable-thp
-    enabled: no
+    enabled: false
     state: stopped
-  become: yes
+  become: true
   # no (real) services in docker containers
   # and no need to bother for molecule testing
   when:
     - ansible_connection!="docker"
     - "'full' in group_names"
-  ignore_errors: yes
+  ignore_errors: true

--- a/roles/splunk/tasks/configure_user-seed.yml
+++ b/roles/splunk/tasks/configure_user-seed.yml
@@ -5,7 +5,7 @@
       stat:
         path: "{{ splunk_home }}/etc/passwd"
       register: splunk_etc_passwd
-      become: yes
+      become: true
       become_user: "{{ splunk_nix_user }}"
 
     - name: Create user-seed.conf file with splunk_admin_username and splunk_admin_password
@@ -14,7 +14,8 @@
         dest: "{{ splunk_home }}/etc/system/local/user-seed.conf"
         owner: "{{ splunk_nix_user }}"
         group: "{{ splunk_nix_group }}"
-      become: yes
+        mode: 0644
+      become: true
       when: not splunk_etc_passwd.stat.exists
   when:
     - splunk_admin_password != 'undefined'

--- a/roles/splunk/tasks/download_and_unarchive.yml
+++ b/roles/splunk/tasks/download_and_unarchive.yml
@@ -9,23 +9,23 @@
     msg: "The upgrade file will be downloaded to {{ splunk_package_path }}/{{ splunk_file }}"
 
 - name: "Download Splunk {{ splunk_install_type }} package"
-  local_action:
-                module: get_url
-                url: "{{ splunk_package_url }}"
-                dest: "{{ splunk_package_path }}/{{ splunk_file }}"
+  get_url:
+    url: "{{ splunk_package_url }}"
+    dest: "{{ splunk_package_path }}/{{ splunk_file }}"
+  delegate_to: localhost
   register: download_result
   retries: 3
   delay: 10
   until: download_result is success
-  run_once: True
+  run_once: true
 
 - name: "Unarchive Splunk {{ splunk_install_type }} package to {{ splunk_home }}"
   unarchive:
-             src: "{{ splunk_package_path }}/{{ splunk_file }}"
-             dest: "{{ splunk_install_path }}"
-             owner: "{{ splunk_nix_user }}"
-             group: "{{ splunk_nix_group }}"
-  become: yes
+    src: "{{ splunk_package_path }}/{{ splunk_file }}"
+    dest: "{{ splunk_install_path }}"
+    owner: "{{ splunk_nix_user }}"
+    group: "{{ splunk_nix_group }}"
+  become: true
   notify:
     - update init.d to accept license
     - start splunk

--- a/roles/splunk/tasks/install_apps.yml
+++ b/roles/splunk/tasks/install_apps.yml
@@ -66,7 +66,7 @@
       fail:
         msg: "The SHC has service ready state of FALSE. Please investigate and re-run Ansible play after resolving."
       when:
-        - service_ready_state == false
+        - not service_ready_state
 
   when: handler == "apply shcluster-bundle"
 
@@ -75,16 +75,16 @@
   synchronize:
     src: "{{ app_src }}"
     dest: "{{ splunk_home }}/{{ app_dest }}/"
-    recursive: yes
-    delete: yes
-    checksum: yes
+    recursive: true
+    delete: true
+    checksum: true
     rsync_opts:
       - "--prune-empty-dirs"
       - "--itemize-changes"
       - "--no-owner"
       - "--no-group"
       - "--no-times"
-  become: yes
+  become: true
   become_user: "{{ splunk_nix_user }}"
   notify: "{{ handler }}"
 
@@ -93,5 +93,5 @@
     path: "{{ splunk_home }}/{{ app_dest }}/{{ item.name }}"
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
-    recurse: yes
-  become: yes
+    recurse: true
+  become: true

--- a/roles/splunk/tasks/install_splunk.yml
+++ b/roles/splunk/tasks/install_splunk.yml
@@ -4,18 +4,18 @@
   block:
     - name: Add nix splunk group
       group:
-             name: "{{ splunk_nix_group }}"
-             state: present
-      become: yes
+        name: "{{ splunk_nix_group }}"
+        state: present
+      become: true
 
     - name: Add nix splunk user
       user:
-            name: "{{ splunk_nix_user }}"
-            groups: "{{ splunk_nix_group }}"
-            home: "{{ splunk_home }}"
-            state: present
-            shell: /bin/bash
-      become: yes
+        name: "{{ splunk_nix_user }}"
+        groups: "{{ splunk_nix_group }}"
+        home: "{{ splunk_home }}"
+        state: present
+        shell: /bin/bash
+      become: true
 
     - name: Allow splunk user to read /var/log
       include_tasks: configure_facl.yml
@@ -43,12 +43,12 @@
 
 - name: Include configure user-seed task
   include_tasks: configure_user-seed.yml
-  when: 
+  when:
     - splunk_admin_password != 'undefined'
 
 - name: Include configure default authentication.conf for AD authentication and admin role mapping
   include_tasks: configure_authentication.yml
-  when: 
+  when:
     - splunk_configure_authentication
     - ad_bind_password != 'undefined'
 

--- a/roles/splunk/tasks/install_utilities.yml
+++ b/roles/splunk/tasks/install_utilities.yml
@@ -3,9 +3,9 @@
 - name: Install useful packages for Linux troubleshooting
   package:
     name: "{{ item }}"
-    state: latest
+    state: present
     update_cache: true
   loop: "{{ linux_packages }}"
-  ignore_errors: yes
-  become: yes
+  ignore_errors: true
+  become: true
   when: install_utilities

--- a/roles/splunk/tasks/main.yml
+++ b/roles/splunk/tasks/main.yml
@@ -12,9 +12,9 @@
     - name: Check if current boot-start configuration is systemd
       stat:
         path: /etc/systemd/system/Splunkd.service
-        follow: yes
+        follow: true
       register: systemd_boot_full
-      become: yes
+      become: true
   when: "'full' in group_names"
 
 - block:
@@ -30,29 +30,29 @@
     - name: Check if current boot-start configuration is systemd
       stat:
         path: /etc/systemd/system/SplunkForwarder.service
-        follow: yes
+        follow: true
       register: systemd_boot_uf
-      become: yes
+      become: true
   when: "'uf' in group_names"
 
 - name: Set systemd_boot var to true if systemd is being used for splunk
   set_fact:
     systemd_boot: true
-  when: (systemd_boot_uf.stat is defined and systemd_boot_uf.stat.exists) or (systemd_boot_full.stat is defined and systemd_boot_full.stat.exists) 
+  when: (systemd_boot_uf.stat is defined and systemd_boot_uf.stat.exists) or (systemd_boot_full.stat is defined and systemd_boot_full.stat.exists)
 
 - name: Check if current boot-start method is init.d
   stat:
     path: /etc/init.d/splunk
-    follow: yes
+    follow: true
   register: initd_boot
-  become: yes
+  become: true
 
 - name: Check if Splunk is installed when no boot-start config has been found
   stat:
     path: "{{ splunk_home }}/bin/splunk"
-    follow: yes
+    follow: true
   register: splunkd_found
-  become: yes
+  become: true
 
 - name: Fail the play if the currently configured boot-start method does match the expected state or boot-start is not enabled
   fail:

--- a/roles/splunk/tasks/post_install.yml
+++ b/roles/splunk/tasks/post_install.yml
@@ -1,9 +1,9 @@
 ---
 - name: Touch .ui_login file to disable first-time login prompt
   file:
-        dest: "{{ splunk_home }}/etc/.ui_login"
-        state: touch
-  become: yes
+    dest: "{{ splunk_home }}/etc/.ui_login"
+    state: touch
+  become: true
   become_user: "{{ splunk_nix_user }}"
   when: "'full' in group_names"
 
@@ -12,8 +12,8 @@
     path: "{{ splunk_home }}/etc"
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
-    recurse: yes
-  become: yes
+    recurse: true
+  become: true
 
 - name: Configure cron job to cleanup crash logs older than 7 days
   include_tasks: add_crashlog_script.yml

--- a/roles/splunk/tasks/remove_splunk.yml
+++ b/roles/splunk/tasks/remove_splunk.yml
@@ -2,13 +2,13 @@
 - include_tasks: splunk_stop.yml
 
 - name: Disable boot-start
-  shell: "{{ splunk_home }}/bin/splunk disable boot-start"
-  become: yes
+  command: "{{ splunk_home }}/bin/splunk disable boot-start"
+  become: true
 
 - name: Remove splunk folder
   file:
     path: "{{ splunk_home }}"
     state: absent
-  become: yes
+  become: true
 
 # Todo: Remove user, group, THP/ulimit files, check for cron jobs/scripts and remove those if present

--- a/roles/splunk/tasks/set_maintenance_mode.yml
+++ b/roles/splunk/tasks/set_maintenance_mode.yml
@@ -1,8 +1,8 @@
 ---
 - name: "{{ state }} maintenance mode on cm"
-  shell: "{{ splunk_home }}/bin/splunk {{ state }} maintenance-mode --answer-yes --skip-validation -auth {{ splunk_auth }}"
-  become: yes
-  become_user: "{{ splunk_nix_user}}"
+  command: "{{ splunk_home }}/bin/splunk {{ state }} maintenance-mode --answer-yes --skip-validation -auth {{ splunk_auth }}"
+  become: true
+  become_user: "{{ splunk_nix_user }}"
   when:
     - state is defined and splunk_auth is defined
     - "'clustermaster' in group_names"

--- a/roles/splunk/tasks/set_upgrade_state.yml
+++ b/roles/splunk/tasks/set_upgrade_state.yml
@@ -1,8 +1,8 @@
 ---
 - name: "Run splunk upgrade-{{ peer_state }} cluster-peers on CM"
-  shell: "{{ splunk_home }}/bin/splunk upgrade-{{ peer_state }} cluster-peers -auth {{ splunk_auth }}"
-  become: yes
-  become_user: "{{ splunk_nix_user}}"
+  command: "{{ splunk_home }}/bin/splunk upgrade-{{ peer_state }} cluster-peers -auth {{ splunk_auth }}"
+  become: true
+  become_user: "{{ splunk_nix_user }}"
   when:
     - peer_state is defined and splunk_auth is defined
     - "'clustermaster' in group_names"

--- a/roles/splunk/tasks/splunk_offline.yml
+++ b/roles/splunk/tasks/splunk_offline.yml
@@ -1,6 +1,9 @@
 ---
 - name: splunk offline
-  shell: "{{ splunk_home }}/bin/splunk offline -auth {{ splunk_auth }}"
-  become: yes
+  command: "{{ splunk_home }}/bin/splunk offline -auth {{ splunk_auth }}"
+  register: splunk_offline_result
+  changed_when: splunk_offline_result.rc == 0
+  failed_when: splunk_offline_result.rc != 0
+  become: true
   become_user: "{{ splunk_nix_user }}"
   no_log: true

--- a/roles/splunk/tasks/splunk_restart.yml
+++ b/roles/splunk/tasks/splunk_restart.yml
@@ -1,6 +1,6 @@
 ---
-- name: restart splunk
+- name: Restart splunk
   service:
     name: "{{ splunk_service }}"
     state: restarted
-  become: yes
+  become: true

--- a/roles/splunk/tasks/splunk_start.yml
+++ b/roles/splunk/tasks/splunk_start.yml
@@ -1,6 +1,6 @@
 ---
-- name: start splunk
+- name: Start splunk
   service:
     name: "{{ splunk_service }}"
     state: started
-  become: yes
+  become: true

--- a/roles/splunk/tasks/splunk_stop.yml
+++ b/roles/splunk/tasks/splunk_stop.yml
@@ -1,6 +1,6 @@
 ---
-- name: stop splunk
+- name: Stop splunk
   service:
     name: "{{ splunk_service }}"
     state: stopped
-  become: yes
+  become: true

--- a/roles/splunk/tasks/upgrade_splunk.yml
+++ b/roles/splunk/tasks/upgrade_splunk.yml
@@ -13,7 +13,7 @@
 - name: Include download and unarchive task
   include_tasks: download_and_unarchive.yml
 
-- name: Enable boot start and accept license 
+- name: Enable boot start and accept license
   include_tasks: configure_splunk_boot.yml
 
 - name: Include mongod tasks to ensure it's in a good state


### PR DESCRIPTION
**Bugfixes**
- Fixed the warnings found by ansible-lint related to spacing issues, truthiness values, use of the shell module, use of local_action, and a few other things
- Fixed a bug in the new check_splunk_status.yml task that was causing plays to fail at this task when splunk was in a stopped state
- Corrected file permissions for the systemd file installed by the configure_thp.yml task