### PR TITLE
Fixed the Version parsing of splunk package request url

### DIFF
--- a/roles/splunk/vars/main.yml
+++ b/roles/splunk/vars/main.yml
@@ -1,8 +1,8 @@
 ---
 # Automatically determine desired splunk version string
 splunk_file: "{{ splunk_package_url | regex_search('(splunk(?:forwarder)?\\-\\d+[^/]*\\.tgz)') }}"
-splunk_v: "{{ splunk_package_url | regex_search('(\\d+.\\d+.\\d+(?:.\\d+)?)') }}"
-splunk_build: "{{ splunk_package_url | regex_search('\\d+.\\d+.\\d+(?:.\\d+)?\\-([^-]+)','\\1') | first }}"
+splunk_v: "{{ splunk_package_url | regex_search('(\\d+\\.\\d+\\.\\d+(?:\\.\\d+)?)') }}"
+splunk_build: "{{ splunk_package_url | regex_search('\\d+\\.\\d+\\.\\d+(?:\\.\\d+)?\\-([^-]+)','\\1') | first }}"
 # Create desired splunk version string (to compare with the output from the splunk version command for upgrades)
 splunk_version: "{{ splunk_product }} {{ splunk_v }} (build {{ splunk_build }})"
 splunk_auth: "{{ splunk_admin_username }}:{{ splunk_admin_password }}"


### PR DESCRIPTION
I had issue with the splunk version parsing from thee newest splunk eenterprise version package.
The regex for the request version was wrong.
splunk-8.1.2-545206cc9f70-Linux-x86_64.tgz -> matched to 8.1.2-545206
