### PR TITLE
Modified conditional handlers for restarting auditd in redhat and non redhat Linux distributions

### DIFF
--- a/roles/splunk/handlers/main.yml
+++ b/roles/splunk/handlers/main.yml
@@ -77,6 +77,14 @@
     state: restarted
   become: true
 
-- name: restart auditd service
+- name: restart redhat auditd service
   command: service auditd condrestart
   become: true
+  when: ansible_os_family == 'RedHat'
+
+- name: restart non-redhat auditd service
+  service:
+    name: auditd
+    state: restarted
+  become: true
+  when: ansible_os_family != 'RedHat'

--- a/roles/splunk/tasks/configure_facl.yml
+++ b/roles/splunk/tasks/configure_facl.yml
@@ -36,8 +36,9 @@
         option: log_group
         value: "{{ splunk_nix_group }}"
       become: true
-      notify: restart auditd service
-      ignore_errors: true
+      notify:
+        - restart redhat auditd service
+        - restart non-redhat auditd service
       when: result_auditd_conf.stat.exists
 
   when: splunk_nix_user != 'root'


### PR DESCRIPTION
**BUGFIXES**
- Created to handlers for restarting auditd service
- One is for RedHat based distributions and the other one is for others (non RedHat based)
- Resolves https://github.com/splunk/ansible-role-for-splunk/issues/42