### PR TITLE
only create ulimits.conf file when using init.d

### DIFF
--- a/roles/splunk/tasks/configure_os.yml
+++ b/roles/splunk/tasks/configure_os.yml
@@ -11,6 +11,7 @@
     group: root
     mode: 0644
   become: true
+  when: splunk_use_initd
 
 - name: Disable THP
   include_tasks: configure_thp.yml


### PR DESCRIPTION
ulimits.conf file is only useful when using init.d. When configured with systemd there is no use for this file