### PR TITLE
Suggest extended handling of licenses

### DIFF
--- a/environments/production/inventory.yml
+++ b/environments/production/inventory.yml
@@ -16,13 +16,6 @@ all:
           hosts:
             my-lm-host:
 
-        # You can preinstall licenses with defining a source and destination (on the licensemaster)
-        #  vars:
-        #    splunk_licenses:
-        #      - name: Name of the license, like Splunk Enterprise 200GB or Splunk ES Premium App
-        #        src: splunk_enterprise.lic
-        #        dest: /tmp/splunk_enterprise.lic
-
         dmc:
           hosts:
             my-dmc-host:

--- a/environments/production/inventory.yml
+++ b/environments/production/inventory.yml
@@ -16,6 +16,11 @@ all:
           hosts:
             my-lm-host:
 
+        # You can preinstall licenses from roles files directory; even possible to have a list of licenses
+        #  vars:
+        #    splunk_licenses:
+        #      - splunk_enterprise.lic
+
         dmc:
           hosts:
             my-dmc-host:

--- a/environments/production/inventory.yml
+++ b/environments/production/inventory.yml
@@ -16,10 +16,12 @@ all:
           hosts:
             my-lm-host:
 
-        # You can preinstall licenses from roles files directory; even possible to have a list of licenses
+        # You can preinstall licenses with defining a source and destination (on the licensemaster)
         #  vars:
         #    splunk_licenses:
-        #      - splunk_enterprise.lic
+        #      - name: Name of the license, like Splunk Enterprise 200GB or Splunk ES Premium App
+        #        src: splunk_enterprise.lic
+        #        dest: /tmp/splunk_enterprise.lic
 
         dmc:
           hosts:

--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -13,7 +13,7 @@ splunk_install_type: undefined # There are two ways to configure this. The easie
 splunk_install_path: /opt # Base directory on the operating system to which splunk should be installed
 splunk_nix_user: splunk
 splunk_nix_group: splunk
-splunk_licenses: undefined
+splunk_licenses: []
 splunk_uri_lm: undefined
 splunk_uri_cm: undefined
 splunk_uri_ds: undefined # e.g. mydeploymentserver.mydomain.com:8089 ; Note that you must also configure the clientName var under either group_vars or host_vars for deploymentclient.conf to be configured

--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -13,6 +13,7 @@ splunk_install_type: undefined # There are two ways to configure this. The easie
 splunk_install_path: /opt # Base directory on the operating system to which splunk should be installed
 splunk_nix_user: splunk
 splunk_nix_group: splunk
+splunk_licenses: undefined
 splunk_uri_lm: undefined
 splunk_uri_cm: undefined
 splunk_uri_ds: undefined # e.g. mydeploymentserver.mydomain.com:8089 ; Note that you must also configure the clientName var under either group_vars or host_vars for deploymentclient.conf to be configured

--- a/roles/splunk/tasks/configure_license.yml
+++ b/roles/splunk/tasks/configure_license.yml
@@ -1,31 +1,34 @@
 ---
 - block:
-  - name: Copy Licenses to Master
+  - name: Copy licenses to the licensemaster
     copy:
-      src: "{{ item }}"
-      dest: "/tmp/{{ item }}"
+      src: "{{ item.src }}"
+      dest: "{{ item.dest }}"
+      owner: "{{ splunk_nix_user }}"
+      group: "{{ splunk_nix_group }}"
+      mode: 0644
     loop: "{{ splunk_licenses }}"
     
-  - name: Install license on licensemaster
-    command: "{{ splunk_home }}/bin/splunk add licenses /tmp/{{ item }} -auth {{ splunk_auth }}"
+  - name: Install licenses on the licensemaster
+    command: "{{ splunk_home }}/bin/splunk add licenses {{ item.dest }} -auth {{ splunk_auth }}"
     become: true
     become_user: "{{ splunk_nix_user }}"
     loop: "{{ splunk_licenses }}"
     ignore_errors: yes
+    no_log: true
     register: license_result
-    changed_when: '"The licenses object has been added" in license_result.stdout'
+    changed_when: license_result.rc == 0
     notify: restart splunk
 
-  - name: Clean Up licenses
+  - name: Cleanup licenses on the licensemaster that were copied
     file:
-      path: "/tmp/{{ item }}"
+      path: "{{ item.dest }}"
       state: absent
     become: true
     loop: "{{ splunk_licenses }}"
 
   when:
     - "'licensemaster' in group_names"
-    - splunk_licenses is defined
     - splunk_licenses != 'undefined'
 
 - name: Set license master_uri

--- a/roles/splunk/tasks/configure_license.yml
+++ b/roles/splunk/tasks/configure_license.yml
@@ -2,31 +2,13 @@
 - block:
   - name: Copy licenses to the licensemaster
     copy:
-      src: "{{ item.src }}"
-      dest: "{{ item.dest }}"
+      src: "{{ item }}"
+      dest: "{{ splunk_home}}/etc/license/enterprise/{{ item }}"
       owner: "{{ splunk_nix_user }}"
       group: "{{ splunk_nix_group }}"
       mode: 0644
     loop: "{{ splunk_licenses }}"
-    
-  - name: Install licenses on the licensemaster
-    command: "{{ splunk_home }}/bin/splunk add licenses {{ item.dest }} -auth {{ splunk_auth }}"
-    become: true
-    become_user: "{{ splunk_nix_user }}"
-    loop: "{{ splunk_licenses }}"
-    ignore_errors: yes
-    no_log: true
-    register: license_result
-    changed_when: license_result.rc == 0
     notify: restart splunk
-
-  - name: Cleanup licenses on the licensemaster that were copied
-    file:
-      path: "{{ item.dest }}"
-      state: absent
-    become: true
-    loop: "{{ splunk_licenses }}"
-
   when:
     - "'licensemaster' in group_names"
     - splunk_licenses != 'undefined'

--- a/roles/splunk/tasks/configure_license.yml
+++ b/roles/splunk/tasks/configure_license.yml
@@ -1,4 +1,33 @@
 ---
+- block:
+  - name: Copy Licenses to Master
+    copy:
+      src: "{{ item }}"
+      dest: "/tmp/{{ item }}"
+    loop: "{{ splunk_licenses }}"
+    
+  - name: Install license on licensemaster
+    command: "{{ splunk_home }}/bin/splunk add licenses /tmp/{{ item }} -auth {{ splunk_auth }}"
+    become: true
+    become_user: "{{ splunk_nix_user }}"
+    loop: "{{ splunk_licenses }}"
+    ignore_errors: yes
+    register: license_result
+    changed_when: '"The licenses object has been added" in license_result.stdout'
+    notify: restart splunk
+
+  - name: Clean Up licenses
+    file:
+      path: "/tmp/{{ item }}"
+      state: absent
+    become: true
+    loop: "{{ splunk_licenses }}"
+
+  when:
+    - "'licensemaster' in group_names"
+    - splunk_licenses is defined
+    - splunk_licenses != 'undefined'
+
 - name: Set license master_uri
   ini_file:
     path: "{{ splunk_home }}/etc/system/local/server.conf"
@@ -12,4 +41,5 @@
   notify: restart splunk
   when:
     - "'full' in group_names"
+    - "'licensemaster' not in group_names"
     - splunk_uri_lm != 'undefined'


### PR DESCRIPTION
I may suggest a little change in the license handling.
The licensemaster should not set the license master uri, it should install the license instead.

So we can define a list of license files in the role/file directory stored in the splunk_licenses variable and set them for the licensemaster (in which way someone prefer)

Error handling of adding licenses via CLI can be ignored, however we need to define when it is changed, so splunk can restart.