### PR TITLE
Fix bug related to start_splunk_handler_fired

### DIFF
--- a/roles/splunk/tasks/main.yml
+++ b/roles/splunk/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Reset value of start_splunk_handler_fired
+  tags: always
+  set_fact:
+    start_splunk_handler_fired: false
+  changed_when: false
+
 - block:
     - name: Configure vars for full package
       tags: always


### PR DESCRIPTION
**Bugfix**
- Fixed a bug that caused Ansible to not restart splunk when a restart was required