### PR TITLE
Fix race condition during idxc configuration

### DIFF
--- a/roles/splunk/handlers/main.yml
+++ b/roles/splunk/handlers/main.yml
@@ -82,3 +82,9 @@
     state: restarted
   become: true
   when: ansible_os_family != 'RedHat'
+
+- name: wait for splunkd
+  wait_for:
+    port: "{{ splunkd_port }}"
+    state: started
+    delay: 5

--- a/roles/splunk/tasks/configure_idxc_manager.yml
+++ b/roles/splunk/tasks/configure_idxc_manager.yml
@@ -27,3 +27,9 @@
     - { option: "search_factor", value: "{{ splunk_idxc_sf }}" }
     - { option: "pass4SymmKey", value: "{{ splunk_idxc_key }}" }
     - { option: "cluster_label", value: "{{ splunk_idxc_label }}" }
+
+- name: Wait for splunkd to come up
+  wait_for:
+    port: "{{ splunkd_port }}"
+    state: started
+    delay: 5

--- a/roles/splunk/tasks/configure_idxc_manager.yml
+++ b/roles/splunk/tasks/configure_idxc_manager.yml
@@ -20,16 +20,12 @@
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
   become: true
-  notify: restart splunk
+  notify: 
+    - restart splunk
+    - wait for splunkd
   loop:
     - { option: "mode", value: "{{ mode_value}}" }
     - { option: "replication_factor", value: "{{ splunk_idxc_rf }}" }
     - { option: "search_factor", value: "{{ splunk_idxc_sf }}" }
     - { option: "pass4SymmKey", value: "{{ splunk_idxc_key }}" }
     - { option: "cluster_label", value: "{{ splunk_idxc_label }}" }
-
-- name: Wait for splunkd to come up
-  wait_for:
-    port: "{{ splunkd_port }}"
-    state: started
-    delay: 5

--- a/roles/splunk/tasks/configure_idxc_member.yml
+++ b/roles/splunk/tasks/configure_idxc_member.yml
@@ -19,3 +19,6 @@
   failed_when: idxc_peer_init_result.rc != 0
   notify: restart splunk
   no_log: true
+  until: idxc_peer_init_result.rc == 0
+  retries: 6
+  delay: 5


### PR DESCRIPTION
- Added a new `wait for splunkd` handler that waits for splunkd to come back up after a restart in `configure_idxc_manager.yml`
- Added an `until` loop to retry indexer cluster member configuration in case the cluster manager is not ready yet