### PR TITLE
Added configure_sysctl.yml to allow users to run dmesg

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Note: Any task with an **adhoc** prefix means that it can be used independently 
 - **configure_idxc_sh.yml** - Configures a search head to join an existing indexer cluster using `splunk_uri_cm` and `splunk_idxc_key`.
 - **configure_license.yml** - Configure the license master URI in server.conf for full Splunk installations when `splunk_uri_lm` has been defined. Note: This could also be accomplished using configure_apps.yml with a git repository.
 - **configure_os.yml** - Increases ulimits for the splunk user and disables Transparent Huge Pages (THP) per Splunk implementation best practices.
+- **configure_sysctl.yml** - Allow splunk user to run `dmesg`, which is needed for some SPlunk_TA_nix scripts to run. Some Debian AMI's have `kernel.dmesg_restrict = 0` set by default.
 - **configure_serverclass.yml** - Generates a new serverclass.conf file from the serverclass.conf.j2 template and installs it to $SPLUNK_HOME/etc/system/local/serverclass.conf.
 - **configure_shc_captain.yml** - Perform a `bootstrap shcluster-captain` using the server list provided in `splunk_shc_uri_list`.
 - **configure_shc_deployer.yml** - Configures a Splunk host to act as a search head deployer by configuring the pass4SymmKey contained in `splunk_shc_key` and the shcluster_label contained in `splunk_shc_label`.

--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -60,6 +60,7 @@ start_splunk_handler_fired: false # Do not change; used to prevent unnecessary s
 add_crashlog_script: false # Set to true to install a script and cron job to automatically cleanup splunk crash logs older than 7 days
 add_diag_script: false # Set to true to install a script and cron job to automatically cleanup splunk diag files older than 30 days
 add_pstack_script: false # Set to true to install a pstack generation script for troubleshooting purposes in $SPLUNK_HOLME/genpstacks.sh
+configure_dmesg_sysctl: false # allow non-root users to run dmesg
 install_utilities: false # Set to true to install the list of packages defined in the linux_packages var after installing splunk
 linux_packages:
   - nload

--- a/roles/splunk/tasks/configure_os.yml
+++ b/roles/splunk/tasks/configure_os.yml
@@ -16,3 +16,7 @@
 - name: Disable THP
   include_tasks: configure_thp.yml
   when: "'full' in group_names"
+
+- name: Enable read for dmesg
+  include_tasks: configure_sysctl.yml
+  when: configure_sysctl == true

--- a/roles/splunk/tasks/configure_sysctl.yml
+++ b/roles/splunk/tasks/configure_sysctl.yml
@@ -1,0 +1,19 @@
+---
+# Allow users to run dmesg. This is needed for the Splunk_TA_nix to run scripts
+- name: Add sysctl for dmesg
+  sysctl:
+    name: kernel.dmesg_restrict
+    value: '0'
+    state: present
+    sysctl_file: /etc/sysctl.d/20-splunk.conf
+    reload: yes
+  register: sysctl_dmesg
+  become: true
+
+- name: Restart procps
+  service:
+    name: procps
+    state: restarted
+  # RHEL does not have the procps service.
+  when: sysctl_dmesg.changed and ansible_os_family == 'Debian'
+  become: true


### PR DESCRIPTION
Ubuntu servers have `kernel.dmesg_restrict = 1`, which prevents some scripts from Splunk_TA_nix app from running.
This adds the ability to configure it to allow the splunk user to run the `dmesg` command.
The default in `main.yml` is set to `configure_dmesg_sysctl: false`