### PR TITLE
disable-thp.service should be enabled and started

### DIFF
--- a/roles/splunk/tasks/configure_thp.yml
+++ b/roles/splunk/tasks/configure_thp.yml
@@ -23,8 +23,8 @@
 - name: Disable THP service
   service:
     name: disable-thp
-    enabled: false
-    state: stopped
+    enabled: yes
+    state: started
   become: true
   # no (real) services in docker containers
   # and no need to bother for molecule testing


### PR DESCRIPTION
The naming is a bit confusing, but the service should be started and enabled