### PR TITLE
Add more licensing options

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Note: Any task with an **adhoc** prefix means that it can be used independently 
 - **configure_idxc_manager.yml** - Configures a Splunk host to act as a manager node using `splunk_idxc_rf`, `splunk_idxc_sf`, `splunk_idxc_key`, and `splunk_idxc_label`.
 - **configure_idxc_member.yml** - Configures a Splunk host as an indexer cluster member using `splunk_uri_cm`, `splunk_idxc_rep_port`, and `splunk_idxc_key`.
 - **configure_idxc_sh.yml** - Configures a search head to join an existing indexer cluster using `splunk_uri_cm` and `splunk_idxc_key`.
-- **configure_license.yml** - Configure the license master URI in server.conf for full Splunk installations when `splunk_uri_lm` has been defined. Note: This could also be accomplished using configure_apps.yml with a git repository.
+- **configure_license.yml** - Configure the license group to the `splunk_license_group` variable defined. Default is `Trial`. Available values are "Trial, Free, Enterprise, Forwarder, Manager or Peer. If set to `Peer`, the `splunk_uri_lm` must be defined. Note: This could also be accomplished using configure_apps.yml with a git repository.
 - **configure_os.yml** - Increases ulimits for the splunk user and disables Transparent Huge Pages (THP) per Splunk implementation best practices.
 - **configure_serverclass.yml** - Generates a new serverclass.conf file from the serverclass.conf.j2 template and installs it to $SPLUNK_HOME/etc/system/local/serverclass.conf.
 - **configure_shc_captain.yml** - Perform a `bootstrap shcluster-captain` using the server list provided in `splunk_shc_uri_list`.

--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -13,6 +13,8 @@ splunk_install_type: undefined # There are two ways to configure this. The easie
 splunk_install_path: /opt # Base directory on the operating system to which splunk should be installed
 splunk_nix_user: splunk
 splunk_nix_group: splunk
+splunk_license_file: [] # This can be a list of license files to copy to the host.
+splunk_license_group: Trial # The default matches with the group splunk ships with. You can also set the value via a group_vars or host_vars file.
 splunk_uri_lm: undefined
 splunk_uri_cm: undefined
 splunk_uri_ds: undefined # e.g. mydeploymentserver.mydomain.com:8089 ; Note that you must also configure the clientName var under either group_vars or host_vars for deploymentclient.conf to be configured

--- a/roles/splunk/tasks/check_splunk_version.yml
+++ b/roles/splunk/tasks/check_splunk_version.yml
@@ -4,6 +4,7 @@
   become: true
   become_user: "{{ splunk_nix_user }}"
   changed_when: false
+  check_mode: no
 
 - name: Get Splunk version number only
   set_fact:

--- a/roles/splunk/tasks/configure_license.yml
+++ b/roles/splunk/tasks/configure_license.yml
@@ -1,30 +1,80 @@
 ---
-- name: Set license master_uri in server.conf
-  ini_file:
-    path: "{{ splunk_home }}/etc/system/local/server.conf"
-    section: license
-    option: master_uri
-    value: "{{ splunk_uri_lm }}"
-    owner: "{{ splunk_nix_user }}"
-    group: "{{ splunk_nix_group }}"
-    mode: 0644
-  become: true
-  notify: restart splunk
-  when:
-    - "'full' in group_names"
-    - splunk_uri_lm != 'undefined'
+# Check splunk version to determine if we use `master_uri` or `manager_uri`.
+- name: Run splunk version command to check currently installed version
+  include_tasks: check_splunk_version.yml
 
-- name: Set pass4SymmKey in the general stanza of server.conf
-  ini_file:
-    path: "{{ splunk_home }}/etc/system/local/server.conf"
-    section: general
-    option: pass4SymmKey
-    value: "{{ splunk_general_key }}"
-    owner: "{{ splunk_nix_user }}"
-    group: "{{ splunk_nix_group }}"
-    mode: 0644
-  become: true
-  notify: restart splunk
+- name: Setting licensing mode based on Splunk version number
+  set_fact:
+    mode_option: "{% if splunk_version_release | float < 9.0 %}master{% else %}manager{% endif %}_uri"
+
+- name: Configure Local License
+  block:
+  - name: Create license/enterprise directory
+    file:
+      path: "{{ splunk_home }}/etc/licenses/enterprise"
+      state: directory
+      mode: "0700"
+      owner: "{{ splunk_nix_user }}"
+      group: "{{ splunk_nix_group }}"
+    become: yes
+    when:
+      - splunk_license_group=="Enterprise"
+  - name: Copy license file
+    copy:
+      src: "{{ item }}"
+      dest: "{{ splunk_home }}/etc/licenses/enterprise/{{ item }}"
+      owner: "{{ splunk_nix_user }}"
+      group: "{{ splunk_nix_group }}"
+      mode: "0600"
+    loop: "{{ splunk_license_file }}"
+    become: yes
+    when:
+      - splunk_license_group=="Enterprise"
+  - name: Remove master_uri when using local license
+    ini_file:
+      path: "{{ splunk_home }}/etc/system/local/server.conf"
+      section: license
+      option: "{{ mode_option }}"
+      value: "{{ splunk_uri_lm }}"
+      owner: "{{ splunk_nix_user }}"
+      group: "{{ splunk_nix_group }}"
+      state: absent
+    become: yes
+  - name: Configure License Group
+    ini_file:
+      path: "{{ splunk_home }}/etc/system/local/server.conf"
+      section: license
+      option: active_group
+      value: "{{ splunk_license_group }}"
+      owner: "{{ splunk_nix_user }}"
+      group: "{{ splunk_nix_group }}"
+    become: yes
+    notify: restart splunk
   when:
-    - "'full' in group_names"
-    - splunk_general_key != 'undefined'
+    - not splunk_license_group=="Peer"
+
+- name: Configure License Peer
+  block:
+  - name: Set license master_uri
+    ini_file:
+      path: "{{ splunk_home }}/etc/system/local/server.conf"
+      section: license
+      option: "{{ mode_option }}"
+      value: "{{ splunk_uri_lm }}"
+      owner: "{{ splunk_nix_user }}"
+      group: "{{ splunk_nix_group }}"
+    become: yes
+
+  - name: Set pass4SymmKey to match LM
+    ini_file:
+      path: "{{ splunk_home }}/etc/system/local/server.conf"
+      section: general
+      option: pass4SymmKey
+      value: "{{ pass4SymmKey }}"
+      owner: "{{ splunk_nix_user }}"
+      group: "{{ splunk_nix_group }}"
+    become: yes
+    notify: restart splunk
+  when:
+    - splunk_license_group=="Peer"
+    - splunk_install_type=="full"


### PR DESCRIPTION
Redesign of the logic of how licenses are configured.
This allows adding license files, change an instance from being a peer to a localslave or set an instance to use the built-in licenses that ship with the application.
Added the option to used `manager_uri` instead of `master_uri` for versions running version 9.0+
The splunk version check now runs in `--check` mode. This prevents checks from failing.