### PR TITLE
configure restartSplunkd on serverclass level

### DIFF
--- a/environments/production/host_vars/my-ds.yml
+++ b/environments/production/host_vars/my-ds.yml
@@ -37,3 +37,14 @@ serverclasses:
           restartSplunkWeb: 0
           restartSplunkd: 1
           stateOnClient: enabled
+
+# Fourth server class example, setting the restartSplunkd on the serverclass level:
+  - serverclass: ALL_WEB
+    restartSplunkd: 1
+    whitelist:
+      - 'webserver1'
+      - 'webserver2'
+    blacklist:
+      - 'webserver*dev'
+    apps:
+      - name: webserver_app

--- a/roles/splunk/templates/serverclass.conf.j2
+++ b/roles/splunk/templates/serverclass.conf.j2
@@ -1,6 +1,15 @@
 # This file is managed by Ansible - DO NOT MODIFY MANUALLY OR VIA SPLUNK WEB
 {% for x in serverclasses %}
 [serverClass:{{ x.serverclass }}]
+{% if x.restartSplunkWeb is defined %}
+restartSplunkWeb = {{ x.restartSplunkWeb }}
+{% endif %}
+{% if x.restartSplunkd is defined %}
+restartSplunkd = {{ x.restartSplunkd }}
+{% endif %}
+{% if x.stateOnClient is defined %}
+stateOnClient = {{ x.stateOnClient }}
+{% endif %}
 {% if x.platform is defined %}
 machineTypesFilter = {{ x.platform }}
 {% endif %}


### PR DESCRIPTION
This allows to configure the deployment server to restart clients not only on a per-app basis, but also on the serverclass level