### PR TITLE
fixes splunk/ansible-role-for-splunk#49

### DIFF
--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -44,6 +44,7 @@ git_server: undefined # e.g. ssh://git@mygithost:1234 - Note that this may be se
 git_key: undefined # Path to SSH key for cloning repositories - Note that this may be set in an all.yml group_var or inside the git_apps dictionary within host_vars
 git_project: undefined
 git_version: master # Configure default version to clone, overridable inside the git_apps dictionary within host_vars
+app_relative_path: # set a sub-path you want to sync within a repo. If the repo contains multiple apps in the root directory, just set this to a trailing slash.
 splunk_app_deploy_path: undefined # Path under $SPLUNK_HOME/ to deploy apps to - Note that this may be set in group_vars, host_vars, playbook vars, or inside the git_apps dictionary within host_vars
 # IDXC Vars
 splunk_idxc_key: mypass4symmkey

--- a/roles/splunk/tasks/configure_apps.yml
+++ b/roles/splunk/tasks/configure_apps.yml
@@ -78,7 +78,7 @@
       loop: "{{ git_apps }}"
       vars:
         app_dest: "{{ item.splunk_app_deploy_path | default(splunk_app_deploy_path) }}"
-        app_src: "{{ git_local_clone_path }}{{ ansible_nodename }}/{{ item.name }}{{ app_relative_path }}"
+        app_src: "{{ git_local_clone_path }}{{ ansible_nodename }}/{{ item.name }}{{ item.app_relative_path | default(app_relative_path) }}"
 
     - name: Cleanup the local directory that was used to manage repos on the target host
       file:

--- a/roles/splunk/tasks/configure_apps.yml
+++ b/roles/splunk/tasks/configure_apps.yml
@@ -78,7 +78,7 @@
       loop: "{{ git_apps }}"
       vars:
         app_dest: "{{ item.splunk_app_deploy_path | default(splunk_app_deploy_path) }}"
-        app_src: "{{ git_local_clone_path }}{{ ansible_nodename }}/{{ item.name }}"
+        app_src: "{{ git_local_clone_path }}{{ ansible_nodename }}/{{ item.name }}{{ app_relative_path }}"
 
     - name: Cleanup the local directory that was used to manage repos on the target host
       file:

--- a/roles/splunk/tasks/install_apps.yml
+++ b/roles/splunk/tasks/install_apps.yml
@@ -90,7 +90,7 @@
 
 - name: Ensure correct permissions are set
   file:
-    path: "{{ splunk_home }}/{{ app_dest }}/{{ item.name }}"
+    path: "{{ splunk_home }}/{{ app_dest }}"
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
     recurse: true


### PR DESCRIPTION
This allows you to have multiple apps in a single repo, and rsync the apps in the correct destination directory.
