### PR TITLE
Explicitly configure Splunk Group and User locally

### DIFF
--- a/roles/splunk/tasks/install_splunk.yml
+++ b/roles/splunk/tasks/install_splunk.yml
@@ -6,6 +6,7 @@
       group:
         name: "{{ splunk_nix_group }}"
         state: present
+        local: true
       become: true
 
     - name: Add nix splunk user
@@ -16,6 +17,7 @@
         append: true
         state: present
         shell: /bin/bash
+        local: true
       become: true
 
     - name: Allow splunk user to read /var/log


### PR DESCRIPTION
# Summary

Explicitly configures the Splunk nix Group and User with the `local: true` stanza in order to ensure no clobbering of netgroups that may or may not be configured.

## Issues Fixed

When trying to add the group without the `local` config, if there is a netgroup configured with the same name as `splunk_nix_group` (say, for people who should be able to SSH into a system with LDAP creds), the group will not be created locally. This then causes the addition of the `splunk_nix_user` in the subsequent task to fail, as ansible will not add a local user to a netgroup.

Explicitly specifying `local: true` for each of these tasks solves this issue that some people may run into.