### PR TITLE
Add the code for the "Manager" option; have both old and new option r…

### DIFF
--- a/roles/splunk/tasks/configure_license.yml
+++ b/roles/splunk/tasks/configure_license.yml
@@ -18,7 +18,7 @@
       group: "{{ splunk_nix_group }}"
     become: yes
     when:
-      - splunk_license_group=="Enterprise"
+      - splunk_license_group=="Enterprise" or splunk_license_group=="Manager"
   - name: Copy license file
     copy:
       src: "{{ item }}"
@@ -29,7 +29,31 @@
     loop: "{{ splunk_license_file }}"
     become: yes
     when:
-      - splunk_license_group=="Enterprise"
+      - splunk_license_group=="Enterprise" or splunk_license_group=="Manager"
+  - name: Set pass4SymmKey on LM
+    ini_file:
+      path: "{{ splunk_home }}/etc/system/local/server.conf"
+      section: general
+      option: pass4SymmKey
+      value: "{{ pass4SymmKey }}"
+      owner: "{{ splunk_nix_user }}"
+      group: "{{ splunk_nix_group }}"
+    become: true
+    notify: restart splunk
+    when:
+      - splunk_license_group=="Manager"
+  - name: Remove master_uri when using local license
+    ini_file:
+      path: "{{ splunk_home }}/etc/system/local/server.conf"
+      section: license
+      option: "{{ item }}"
+      owner: "{{ splunk_nix_user }}"
+      group: "{{ splunk_nix_group }}"
+      state: absent
+    with_items:
+      - manager_uri
+      - master_uri
+    become: true
   - name: Remove master_uri when using local license
     ini_file:
       path: "{{ splunk_home }}/etc/system/local/server.conf"


### PR DESCRIPTION
The README stated, that it is possible to have manager as value, but for me I didn't see any code for the Manager.
So I added the code for the manager and set the pass4SymmKey.

Additionally I changed the code, to remove the manager_uri, not even depending on the current splunk version.
No both the old and the new options were removed, in such cases were wee would change the license group, and splunk upgrade from version <9.0 to >= 9.x