### PR TITLE
feat(install_utilities): send list to package module

### DIFF
--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -72,19 +72,3 @@ add_pstack_script: false # Set to true to install a pstack generation script for
 configure_dmesg: false
 install_utilities: false # Set to true to install the list of packages defined in the linux_packages var after installing splunk
 use_tuned_thp: false
-linux_packages:
-  - nload
-  - iotop
-  - iftop
-  - sysstat
-  - telnet
-  - tcpdump
-  - htop
-  - atop
-  - lsof
-  - policycoreutils-python
-  - policycoreutils
-  - setroubleshoot
-  - nethogs
-  - gdb
-  - bind-utils

--- a/roles/splunk/tasks/configure_os.yml
+++ b/roles/splunk/tasks/configure_os.yml
@@ -1,8 +1,5 @@
 ---
 # Task to configure ulimits and THP for Splunk
-- name: Include OS family-specific variables
-  include_vars: "{{ ansible_os_family }}.yml"
-
 - name: Set ulimits for splunk
   template:
     src: splunk_ulimits.conf.j2

--- a/roles/splunk/tasks/install_utilities.yml
+++ b/roles/splunk/tasks/install_utilities.yml
@@ -2,10 +2,9 @@
 # Todo: Use vars to define distribution-specific packages. For now, it'll just ignore errors for any package names that aren't available for your distro.
 - name: Install useful packages for Linux troubleshooting
   package:
-    name: "{{ item }}"
+    name: "{{ linux_packages }}"
     state: present
     update_cache: true
-  loop: "{{ linux_packages }}"
   ignore_errors: true
   become: true
   when: install_utilities

--- a/roles/splunk/tasks/install_utilities.yml
+++ b/roles/splunk/tasks/install_utilities.yml
@@ -5,6 +5,5 @@
     name: "{{ linux_packages }}"
     state: present
     update_cache: true
-  ignore_errors: true
   become: true
   when: install_utilities

--- a/roles/splunk/tasks/main.yml
+++ b/roles/splunk/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: include distribution vars
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_os_family }}{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_os_family }}.yml"
+
 - name: Reset value of start_splunk_handler_fired
   tags: always
   set_fact:

--- a/roles/splunk/vars/Debian.yml
+++ b/roles/splunk/vars/Debian.yml
@@ -1,2 +1,16 @@
 ---
 global_bashrc: /etc/bash.bashrc
+linux_packages:
+  - nload
+  - iotop
+  - iftop
+  - sysstat
+  - telnet
+  - tcpdump
+  - htop
+  - atop
+  - lsof
+  - policycoreutils
+  - nethogs
+  - gdb
+  - dnsutils

--- a/roles/splunk/vars/RedHat.yml
+++ b/roles/splunk/vars/RedHat.yml
@@ -1,3 +1,19 @@
 ---
 global_bashrc: /etc/bashrc
 chk_config_cmd: chkconfig --add disable-thp
+linux_packages:
+  - nload
+  - iotop
+  - iftop
+  - sysstat
+  - telnet
+  - tcpdump
+  - htop
+  - atop
+  - lsof
+  - policycoreutils-python
+  - policycoreutils
+  - setroubleshoot
+  - nethogs
+  - gdb
+  - bind-utils

--- a/roles/splunk/vars/RedHat8.yml
+++ b/roles/splunk/vars/RedHat8.yml
@@ -1,0 +1,19 @@
+---
+global_bashrc: /etc/bashrc
+chk_config_cmd: chkconfig --add disable-thp
+linux_packages:
+  - nload
+  - iotop
+  - iftop
+  - sysstat
+  - telnet
+  - tcpdump
+  - htop
+  - atop
+  - lsof
+  - policycoreutils-python-utils
+  - policycoreutils
+  - setroubleshoot
+  - nethogs
+  - gdb
+  - bind-utils


### PR DESCRIPTION
Instead of looping through the list it is recommended to send a list to apt/yum when install multiple packages.

*When used with a `loop:` each package will be processed individually, it is much more efficient to pass the list directly to the name option.*   https://docs.ansible.com/ansible/latest/collections/ansible/builtin/yum_module.html  