### PR TITLE
forcing usage of luseradd/lgroupadd broke some distros

### DIFF
--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -15,7 +15,7 @@ splunk_install_path: /opt # Base directory on the operating system to which splu
 least_privileged: false # Do not change. This get automatically set in `tasks/main.yml` based on the version and install type.
 splunk_nix_user: splunk
 splunk_nix_group: splunk
-local_os_user: false # Whenther or not to force creation of a user using the `useradd` or not.
+local_os_user: false # Whenther or not to force creation of a user using the `luseradd` or not.
 local_os_group: false # Whether or not to force creation of a group using the `lgroupadd` or not.
 splunk_uri_lm: undefined
 splunk_license_file: [] # This can be a list of license files to copy to the host.

--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -15,6 +15,8 @@ splunk_install_path: /opt # Base directory on the operating system to which splu
 least_privileged: false # Do not change. This get automatically set in `tasks/main.yml` based on the version and install type.
 splunk_nix_user: splunk
 splunk_nix_group: splunk
+local_os_user: false # Whenther or not to force creation of a user using the `useradd` or not.
+local_os_group: false # Whether or not to force creation of a group using the `lgroupadd` or not.
 splunk_uri_lm: undefined
 splunk_license_file: [] # This can be a list of license files to copy to the host.
 splunk_license_group: Trial # The default matches with the group splunk ships with. You can also set the value via a group_vars or host_vars file.

--- a/roles/splunk/tasks/install_splunk.yml
+++ b/roles/splunk/tasks/install_splunk.yml
@@ -6,7 +6,7 @@
       group:
         name: "{{ splunk_nix_group }}"
         state: present
-        local: true
+        local: "{{ local_os_group }}"
       become: true
 
     - name: Add nix splunk user
@@ -17,7 +17,7 @@
         append: true
         state: present
         shell: /bin/bash
-        local: true
+        local: "{{ local_os_user }}"
       become: true
 
     - name: Allow splunk user to read /var/log


### PR DESCRIPTION
Some distros either don't have the `luseradd` and `lgroupadd` commands, or they are just broken.

This sets the `local: false` as the default (since this is how it has been before the recent change).
If you wish to force to create local user and group, set the `local_os_user` and `local_os_group` to `true`.