### PR TITLE
only daemon-reload when systemd is available

### DIFF
--- a/roles/splunk/handlers/main.yml
+++ b/roles/splunk/handlers/main.yml
@@ -16,6 +16,7 @@
   when: splunk_use_initd and ansible_os_family == "RedHat" and ansible_distribution_major_version|int > 6
 
 - name: reload systemctl daemon
+  when: ansible_service_mgr == "systemd"
   systemd:
     daemon_reload: true
   become: true


### PR DESCRIPTION
When  a notify to the `reload systemctl daemon` is sent, and the system does not support systemd, it errors out.

With this change, that command will only run if `ansible_service_mgr` is `systemd`.