### PR TITLE
Add amazon linux

### DIFF
--- a/roles/splunk/tasks/install_splunk.yml
+++ b/roles/splunk/tasks/install_splunk.yml
@@ -12,9 +12,8 @@
     - name: Add nix splunk user
       user:
         name: "{{ splunk_nix_user }}"
-        groups: "{{ splunk_nix_group }}"
+        group: "{{ splunk_nix_group }}"
         home: "{{ splunk_home }}"
-        append: true
         state: present
         shell: /bin/bash
         local: "{{ local_os_user }}"

--- a/roles/splunk/tasks/main.yml
+++ b/roles/splunk/tasks/main.yml
@@ -2,6 +2,8 @@
 - name: include distribution vars
   include_vars: "{{ item }}"
   with_first_found:
+    - "{{ ansible_distribution }}{{ ansible_distribution_version }}.yml"
+    - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}{{ ansible_distribution_major_version }}.yml"
     - "{{ ansible_os_family }}.yml"
 

--- a/roles/splunk/vars/Amazon2.yml
+++ b/roles/splunk/vars/Amazon2.yml
@@ -1,0 +1,12 @@
+global_bashrc: /etc/bashrc
+chk_config_cmd: chkconfig --add disable-thp
+linux_packages:
+  - sysstat
+  - telnet
+  - tcpdump
+  - htop
+  - lsof
+  - policycoreutils-python
+  - policycoreutils
+  - gdb
+  - bind-utils


### PR DESCRIPTION
Some utilities are not available by default in Amazon Linux, so I added `Amazon2.yml` to fix that

Replaced `groups` with `group` when creating the user, since we are not trying to add the `splunk_nix_user` to additional groups, we want their primary group to be `splunk_nix_group`.