### PR TITLE
Add opensuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)&nbsp;
 [![GitHub release](https://img.shields.io/github/v/tag/splunk/ansible-role-for-splunk?sort=semver&label=Version)](https://github.com/splunk/ansible-role-for-splunk/releases)
 
-This repository contains Splunk's official Ansible role for performing Splunk administration of remote hosts over SSH. This role can manage Splunk Enterprise and Universal Forwarders that are on Linux-based platforms (CentOS/Redhat/Ubuntu), as well as deploy configurations from Git repositories. Example playbooks and inventory files are also provided to help new Ansible users make the most out of this project.
+This repository contains Splunk's official Ansible role for performing Splunk administration of remote hosts over SSH. This role can manage Splunk Enterprise and Universal Forwarders that are on Linux-based platforms (CentOS/Redhat/Ubuntu/Amazon Linux/OpenSUSE), as well as deploy configurations from Git repositories. Example playbooks and inventory files are also provided to help new Ansible users make the most out of this project.
 
 ansible-role-for-splunk is used by the Splunk@Splunk team to manage Splunk's corporate deployment of Splunk.
 

--- a/roles/splunk/tasks/configure_facl.yml
+++ b/roles/splunk/tasks/configure_facl.yml
@@ -1,6 +1,11 @@
 ---
 - name: Configure file access control list (facl) settings for splunk user
   block:
+    - name: Install acl package
+      package:
+        name: "acl"
+        state: present
+      become: True
     - name: Set default facl to allow splunk user to read /var/log
       acl:
         path: /var/log

--- a/roles/splunk/tasks/disable_kvstore.yml
+++ b/roles/splunk/tasks/disable_kvstore.yml
@@ -1,0 +1,10 @@
+---
+- name: Disable KVStore
+  when: ansible_system == "Linux"
+  ini_file:
+    path: "{{ splunk_home }}/etc/system/local/server.conf"
+    section: kvstore
+    option: disabled
+    value: "true"
+  become: True
+  become_user: "{{ splunk_nix_user }}"

--- a/roles/splunk/tasks/upgrade_splunk.yml
+++ b/roles/splunk/tasks/upgrade_splunk.yml
@@ -13,6 +13,13 @@
 - name: Include download and unarchive task
   include_tasks: download_and_unarchive.yml
 
+- name: Disbale KVStore on UF when upgrading from 8.x to 9.0
+  when:
+    - splunk_version_release is version(9, '<')
+    - splunk_package_version is version(9, '>=')
+    - splunk_install_type == "uf"
+  include_tasks: disable_kvstore.yml
+
 - name: Include accept license task
   include_tasks: splunk_license_accept.yml
 

--- a/roles/splunk/vars/Suse.yml
+++ b/roles/splunk/vars/Suse.yml
@@ -1,0 +1,17 @@
+---
+global_bashrc: /etc/bash.bashrc
+linux_packages:
+  - nload
+  - iotop
+  - iftop
+  - sysstat
+  - telnet
+  - tcpdump
+  - htop
+  - atop
+  - lsof
+  - policycoreutils-python
+  - policycoreutils
+  - nethogs
+  - gdb
+  - bind-utils


### PR DESCRIPTION
* Adds support for OpenSUSE (tested on version 15.4 only).
* Install `acl` package if we need to set acls. The install will fail if the `setfacl` command does not exist.
* Workaround for a bug in the UF code which caused an upgrade from 8.x to version 9,0 to try to migrate mongodb, which does not exist on a UF, there fore causing the upgrade to hang for 5 minutes till it timed out.
