### PR TITLE
Fixes splunk/ansible-role-for-splunk#109

### DIFF
--- a/roles/splunk/tasks/configure_facl.yml
+++ b/roles/splunk/tasks/configure_facl.yml
@@ -20,13 +20,12 @@
         - true
         - false
 
-    - name: Add logrotate script to enforce splunk user facls
-      template:
-        src: splunk_facl.j2
-        dest: /etc/logrotate.d/splunk_facl
-        owner: root
-        group: root
-      become: true
+    - name: Add setfacl to logrotate script
+      lineinfile:
+        path: /etc/logrotate.d/syslog
+        insertbefore: '  endscript'
+        line: '        /usr/bin/setfacl -Rm u:{{ splunk_nix_user }}:rx /var/log'
+      become: True
 
     - name: Check if auditd.conf is present
       stat:

--- a/roles/splunk/templates/splunk_facl.j2
+++ b/roles/splunk/templates/splunk_facl.j2
@@ -1,5 +1,0 @@
-{
-    postrotate
-        /usr/bin/setfacl -Rm u:{{ splunk_nix_user }}:rx /var/log
-    endscript
-}


### PR DESCRIPTION
Switch to using the `lineinfile` module instead of a template. This will add the `setfacl` command to where is belongs instead of in a separate script, which is prone to break.