### PR TITLE
Fix setfacl task

### DIFF
--- a/roles/splunk/tasks/configure_facl.yml
+++ b/roles/splunk/tasks/configure_facl.yml
@@ -25,7 +25,8 @@
         path: /etc/logrotate.d/syslog
         insertbefore: '  endscript'
         line: '        /usr/bin/setfacl -Rm u:{{ splunk_nix_user }}:rx /var/log'
-      become: True
+        create: true
+      become: true
 
     - name: Check if auditd.conf is present
       stat:


### PR DESCRIPTION
A [recent commit](https://github.com/splunk/ansible-role-for-splunk/commit/9df2892e86753793aa4e1d653ebd58c36b47df3e) changed the module that was used in `configure_facl.yaml` and causes the role to fail with a `file not found` error during splunk installation when `path: /etc/logrotate.d/syslog` does not already exist on the target host. 

This is due to the [lineinfile module](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/lineinfile_module.html#parameters) defaulting the `create` parameter to `false`. This PR sets `create: true` to remedy the issue.