### PR TITLE
fix redhat auditd restart handler

### DIFF
--- a/roles/splunk/handlers/main.yml
+++ b/roles/splunk/handlers/main.yml
@@ -73,7 +73,9 @@
   when: not start_splunk_handler_fired
 
 - name: restart redhat auditd service
-  command: service auditd condrestart
+  shell: |
+    service auditd stop
+    service auditd start
   become: true
   when: ansible_os_family == 'RedHat'
 


### PR DESCRIPTION
On some version of RHEL based systems, the only way to restart `auditd` is by stopping it, and starting it up using the legacy `service` command. Using `codrestart` on RHEL 8 may cause the task to hang.

https://access.redhat.com/solutions/2664811