### PR TITLE
Require acl package. Fix logrotate and auditd

### DIFF
--- a/roles/splunk/handlers/main.yml
+++ b/roles/splunk/handlers/main.yml
@@ -73,7 +73,9 @@
   when: not start_splunk_handler_fired
 
 - name: restart redhat auditd service
-  command: service auditd condrestart
+  shell: |
+    service auditd stop
+    service auditd start
   become: true
   when: ansible_os_family == 'RedHat'
 

--- a/roles/splunk/tasks/configure_facl.yml
+++ b/roles/splunk/tasks/configure_facl.yml
@@ -22,8 +22,8 @@
 
     - name: Add setfacl to logrotate script
       lineinfile:
-        path: /etc/logrotate.d/syslog
-        insertbefore: '  endscript'
+        path: "{{ logrotate_file }}"
+        insertbefore: 'endscript'
         line: '        /usr/bin/setfacl -Rm u:{{ splunk_nix_user }}:rx /var/log'
       become: True
 

--- a/roles/splunk/tasks/install_splunk.yml
+++ b/roles/splunk/tasks/install_splunk.yml
@@ -1,5 +1,8 @@
 ---
 #  This task should be used for fresh installations of Splunk, refer to upgrade_splunk.yml for upgrades
+- name: Install Required Packages
+  include_tasks: prereqs.yml
+
 - name: Block for non-root splunk user setup
   block:
     - name: Add nix splunk group

--- a/roles/splunk/tasks/main.yml
+++ b/roles/splunk/tasks/main.yml
@@ -7,6 +7,9 @@
     - "{{ ansible_os_family }}{{ ansible_distribution_major_version }}.yml"
     - "{{ ansible_os_family }}.yml"
 
+- name: Include prerequisites
+  include_tasks: prereqs.yml
+
 - name: Reset value of start_splunk_handler_fired and configure_boot_start
   tags: always
   set_fact:

--- a/roles/splunk/tasks/prereqs.yml
+++ b/roles/splunk/tasks/prereqs.yml
@@ -1,0 +1,6 @@
+---
+- name: install acl package
+  ansible.builtin.package:
+    name: acl
+    state: present
+  become: True

--- a/roles/splunk/vars/Debian.yml
+++ b/roles/splunk/vars/Debian.yml
@@ -15,3 +15,4 @@ linux_packages:
   - gdb
   - dnsutils
 firewall_service: ufw
+logrotate_file: /etc/logrotate.d/rsyslog

--- a/roles/splunk/vars/RedHat.yml
+++ b/roles/splunk/vars/RedHat.yml
@@ -18,3 +18,4 @@ linux_packages:
   - gdb
   - bind-utils
 firewall_service: firewalld
+logrotate_file: /etc/logrotate.d/syslog


### PR DESCRIPTION
The `Check for existing /opt/splunkforwarder/etc/passwd` fails if the `acl` package is not installed. Observed on Debian servers with minimal installation.

The `prereqs.yml` can be used in the future to install packages required for the basic installation operation, even if `install_utilities` is set to false.