### PR TITLE
[SAS-8189] added splunk_install_type conditional for var population

### DIFF
--- a/roles/splunk/tasks/main.yml
+++ b/roles/splunk/tasks/main.yml
@@ -47,7 +47,7 @@
         splunk_service: "{{ systemd_unit }}"
       when:
         -  desired_start_method == "systemd"
-  when: "'full' in group_names"
+  when: ('full' in group_names or splunk_install_type == "full")
 
 - block:
     - name: Configure vars for uf package
@@ -73,7 +73,7 @@
         splunk_service: "{{ systemd_unit }}"
       when:
         - desired_start_method == "systemd"
-  when: "'uf' in group_names"
+  when: ('uf' in group_names or splunk_install_type == "uf")
 
 - name: Configure var for splunk init.d service handler
   set_fact:


### PR DESCRIPTION
In cases where the inventory is not splunk specific, and does not have the hierarchy of `full` and `uf`, we want to still be able to install agents on them. It is already documented [here](https://github.com/splunk/ansible-role-for-splunk/blob/master/roles/splunk/defaults/main.yml#L14), that the `splunk_install_type` can be defined in `host_vars` or `group_vars`.