### PR TITLE
Add missing no_log directives

### DIFF
--- a/roles/splunk/tasks/configure_dmc.yml
+++ b/roles/splunk/tasks/configure_dmc.yml
@@ -12,6 +12,7 @@
   loop: "{{ query('inventory_hostnames', 'all:!indexer') }}"
   become: true
   become_user: "{{ splunk_nix_user }}"
+  no_log: true
 
 - name: Configure monitoring console in auto mode
   community.general.ini_file:

--- a/roles/splunk/tasks/set_maintenance_mode.yml
+++ b/roles/splunk/tasks/set_maintenance_mode.yml
@@ -3,6 +3,7 @@
   command: "{{ splunk_home }}/bin/splunk {{ state }} maintenance-mode --answer-yes --skip-validation -auth {{ splunk_auth }}"
   become: true
   become_user: "{{ splunk_nix_user }}"
+  no_log: true
   when:
     - state is defined and splunk_auth is defined
     - "'clustermanager' in group_names"

--- a/roles/splunk/tasks/set_upgrade_state.yml
+++ b/roles/splunk/tasks/set_upgrade_state.yml
@@ -3,6 +3,7 @@
   command: "{{ splunk_home }}/bin/splunk upgrade-{{ peer_state }} cluster-peers -auth {{ splunk_auth }}"
   become: true
   become_user: "{{ splunk_nix_user }}"
+  no_log: true
   when:
     - peer_state is defined and splunk_auth is defined
     - "'clustermanager' in group_names"


### PR DESCRIPTION
When using automation platforms for ansible, like AWX/Tower, users will likely use logging for their plays. 
Without the now added no_log on the changed tasks, the credentials of the splunk admin user might be unintentionally exposed as clear text in log files and reports. 