### PR TITLE
Splunk license file

### DIFF
--- a/roles/splunk/tasks/configure_license.yml
+++ b/roles/splunk/tasks/configure_license.yml
@@ -21,8 +21,8 @@
       - splunk_license_group=="Enterprise"
   - name: Copy license file
     copy:
-      src: "{{ item }}"
-      dest: "{{ splunk_home }}/etc/licenses/enterprise/{{ item }}"
+      src: "{{ item.src | default(item) }}"
+      dest: "{{ splunk_home }}/etc/licenses/enterprise/{{ item.dest | default(item) }}"
       owner: "{{ splunk_nix_user }}"
       group: "{{ splunk_nix_group }}"
       mode: "0600"

--- a/roles/splunk/tasks/configure_license.yml
+++ b/roles/splunk/tasks/configure_license.yml
@@ -28,6 +28,7 @@
       mode: "0600"
     loop: "{{ splunk_license_file }}"
     become: yes
+    notify: restart splunk
     when:
       - splunk_license_group=="Enterprise"
   - name: "Remove {{ mode_option }} when using local license"


### PR DESCRIPTION
Allow license files to be stored in custom src dir for better organization.

Retains backwards compatability by using `default` filter.

Example Var definition
```yaml
splunk_license_file:
  - src: licenses/splunk1.lic
    dest: splunk1.lic
  - src: licenses/Splunk2.lic
    dest: Splunk2.lic
```