### PR TITLE
feat(cron): set permissions on cron scripts/jobs to splunk

### DIFF
--- a/roles/splunk/tasks/add_crashlog_script.yml
+++ b/roles/splunk/tasks/add_crashlog_script.yml
@@ -3,8 +3,8 @@
   template:
     src: cleanup_crashlogs.sh.j2
     dest: "{{ splunk_home }}/cleanup_crashlogs.sh"
-    owner: root
-    group: root
+    owner: "{{ splunk_nix_user }}"
+    group: "{{ splunk_nix_group }}"
     mode: 0755
   become: true
 
@@ -12,6 +12,8 @@
   cron:
     name: "Run cleanup_crashlogs.sh"
     state: present
+    cron_file: cleanup_crashlogs
+    user: "{{ splunk_nix_user }}"
     job: "{{ splunk_home }}/cleanup_crashlogs.sh"
     hour: 0
     minute: 0

--- a/roles/splunk/tasks/add_diag_script.yml
+++ b/roles/splunk/tasks/add_diag_script.yml
@@ -3,8 +3,8 @@
   template:
     src: cleanup_diags.sh.j2
     dest: "{{ splunk_home }}/cleanup_diags.sh"
-    owner: root
-    group: root
+    owner: "{{ splunk_nix_user }}"
+    group: "{{ splunk_nix_group }}"
     mode: 0755
   become: true
 
@@ -12,6 +12,8 @@
   cron:
     name: "Run cleanup_diags.sh"
     state: present
+    cron_file: cleanup_diags
+    user: "{{ splunk_nix_user }}"
     job: "{{ splunk_home }}/cleanup_diags.sh"
     hour: 0
     minute: 0


### PR DESCRIPTION
Following the "least privilege" model we should only be running things as root when absolutely necessary.

Also migrate from crontab to cron.d to isolate jobs into separate files for more granular management.