### PR TITLE
Shcluster fixes

### DIFF
--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -42,6 +42,7 @@ splunk_force_kill: False
 systemd_unit_full: Splunkd # You can change this in `host_vars` or `group_vars` to customize the service name.
 systemd_unit_uf: SplunkForwarder # You can change this in `host_vars` or `group_vars` to customize the service name.
 splunk_disable_mgmt_port: false # If set to true, will disable splunkd management port during installation
+splunk_mgmt_uri: "{{ ansible_fqdn }}" # If the `ansible_fqdn` is not resolvable by other hosts, you can set it to something like `ansible_facts.default_ipv4` in `host_vars` or `group_vars` to use the IP address instead.
 splunkd_port: 8089 # If changed, will overwrite the default port number used by splunkd
 git_local_clone_path: ~/ # Base directory under which repositories for app deplyoment should be cloned to
 git_server: undefined # e.g. ssh://git@mygithost:1234 - Note that this may be set in an all.yml group_var or inside the git_apps dictionary within host_vars
@@ -67,7 +68,7 @@ splunk_shc_rf: 3
 splunk_shc_rep_port: 8100
 splunk_shc_target_group: shc
 splunk_shc_deployer: "{{ groups['shdeployer'] | first }}" # If you manage multiple SHCs, configure the var value in group_vars
-splunk_shc_uri_list: "{% for h in groups[splunk_shc_target_group] %}https://{{ hostvars[h].ansible_fqdn }}:{{ splunkd_port }}{% if not loop.last %},{% endif %}{% endfor %}" # If you manage multiple SHCs, configure the var value in group_vars
+splunk_shc_uri_list: "{% for h in groups[splunk_shc_target_group] %}https://{{ hostvars[h].splunk_mgmt_uri }}:{{ splunkd_port }}{% if not loop.last %},{% endif %}{% endfor %}" # If you manage multiple SHCs, configure the var value in group_vars
 start_splunk_handler_fired: false # Do not change; used to prevent unnecessary splunk restarts
 # Linux and scripting related vars
 add_crashlog_script: false # Set to true to install a script and cron job to automatically cleanup splunk crash logs older than 7 days

--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -42,7 +42,7 @@ splunk_force_kill: False
 systemd_unit_full: Splunkd # You can change this in `host_vars` or `group_vars` to customize the service name.
 systemd_unit_uf: SplunkForwarder # You can change this in `host_vars` or `group_vars` to customize the service name.
 splunk_disable_mgmt_port: false # If set to true, will disable splunkd management port during installation
-splunk_mgmt_uri: "{{ ansible_fqdn }}" # If the `ansible_fqdn` is not resolvable by other hosts, you can set it to something like `ansible_facts.default_ipv4` in `host_vars` or `group_vars` to use the IP address instead.
+splunk_mgmt_uri: "{{ ansible_fqdn }}" # If the `ansible_fqdn` is not resolvable by other hosts, you can set it to something like `ansible_facts.default_ipv4.address` in `host_vars` or `group_vars` to use the IP address instead.
 splunkd_port: 8089 # If changed, will overwrite the default port number used by splunkd
 git_local_clone_path: ~/ # Base directory under which repositories for app deplyoment should be cloned to
 git_server: undefined # e.g. ssh://git@mygithost:1234 - Note that this may be set in an all.yml group_var or inside the git_apps dictionary within host_vars

--- a/roles/splunk/tasks/configure_shc_deployer.yml
+++ b/roles/splunk/tasks/configure_shc_deployer.yml
@@ -1,16 +1,33 @@
 ---
-- name: Configure shclustering stanza for deployer
+- name: Extract encrypted value
+  include_tasks: check_decrypted_secret.yml
+  vars:
+    req_secret_conf: server
+    req_secret_section: shclustering
+    req_secret_option: pass4SymmKey
+
+- name: Configure pass4SymmKey in  shclustering stanza for deployer
   ini_file:
     path: "{{ splunk_home }}/etc/system/local/server.conf"
     section: shclustering
-    option: "{{ item.option }}"
-    value: "{{ item.value }}"
+    option: pass4SymmKey
+    value: "{{ splunk_shc_key }}"
     mode: 0644
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
   become: true
   notify: restart splunk
   no_log: true
-  loop:
-    - { option: "pass4SymmKey", value: "{{ splunk_shc_key }}" }
-    - { option: "shcluster_label", value: "{{ splunk_shc_label }}" }
+  when: encrypted_secret_value.stdout == "" or (splunk_shc_key != decrypted_secret_value.stdout | default(''))
+
+- name: Configure shcluster_label in shclustering stanza for deployer
+  community.general.ini_file:
+    path: "{{ splunk_home }}/etc/system/local/server.conf"
+    section: shclustering
+    option: shcluster_label
+    value: "{{ splunk_shc_label }}"
+    mode: 0644
+    owner: "{{ splunk_nix_user }}"
+    group: "{{ splunk_nix_group }}"
+  become: true
+  notify: restart splunk

--- a/roles/splunk/tasks/configure_shc_members.yml
+++ b/roles/splunk/tasks/configure_shc_members.yml
@@ -1,6 +1,6 @@
 ---
 - name: Initialize shc config
-  command: "{{ splunk_home }}/bin/splunk init shcluster-config -auth {{ splunk_auth }} -mgmt_uri https://{{ ansible_fqdn }}:{{ splunkd_port }} -replication_port {{ splunk_shc_rep_port }} -replication_factor {{ splunk_shc_rf }} -conf_deploy_fetch_url https://{{ splunk_shc_deployer }}:{{ splunkd_port }} -secret {{ splunk_shc_key }} -shcluster_label {{ splunk_shc_label }}"
+  command: "{{ splunk_home }}/bin/splunk init shcluster-config -auth {{ splunk_auth }} -mgmt_uri https://{{ splunk_mgmt_uri }}:{{ splunkd_port }} -replication_port {{ splunk_shc_rep_port }} -replication_factor {{ splunk_shc_rf }} -conf_deploy_fetch_url https://{{ splunk_shc_deployer }}:{{ splunkd_port }} -secret {{ splunk_shc_key }} -shcluster_label {{ splunk_shc_label }}"
   become: true
   become_user: "{{ splunk_nix_user }}"
   register: shc_init_result

--- a/roles/splunk/tasks/slack_messenger.yml
+++ b/roles/splunk/tasks/slack_messenger.yml
@@ -9,7 +9,7 @@
   ignore_errors: true
   run_once: true
   loop:
-    - "****************\n*Starting new Ansible play...*\n```Ansible Role: {{ role_name }}\nAnsible Task: {{ deployment_task }}\nTarget Host: {{ ansible_fqdn }}\nStart Time: {{ ansible_date_time.iso8601 }}```"
+    - "****************\n*Starting new Ansible play...*\n```Ansible Role: {{ role_name }}\nAnsible Task: {{ deployment_task }}\nTarget Host: {{ ansible_facts.hostname }}\nStart Time: {{ ansible_date_time.iso8601 }}```"
   when:
     - slack_token != 'undefined'
     - slack_channel != 'undefined'


### PR DESCRIPTION
* In some cases, using `ansible_fqdn` will set it to `localhost`, which breaks shclustering. This allows you to use a different ansible_fact to set the correct value or the IP address.
* Decrypt `pass4SymmKey` in `[shclustering]` stanza to avoid changes when encrypted value matches the desired key.
