### PR TITLE
Change log level in cfg and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ This section contains additional reference documentation.
 
 Note: Any task with an **adhoc** prefix means that it can be used independently as a `deployment_task` in a playbook. You can use the tasks to resolve various Splunk problems or perform one-time activities, such as decommissioning an indexer from an indexer cluster.
 
+- **adhoc_change_log_level.yml** - Changes the log-level at the CLI level, then makes sure `log-local.cfg` exists, and adds or modifies the the log level in there. Requires the variables `splunk_component` and `splunk_component_log_level` provided to the task.
 - **adhoc_clean_dispatch.yml** - This task is intended to be used for restoring service to search heads should the dispatch directory become full. You should not need to use this task in a healthy environment, but it is at your disposal should the need arise. The task will stop splunk, remove all files in the dispatch directory, and then start splunk.
 - **adhoc_configure_hostname** - Configure a Splunk server's hostname using the value from inventory_hostname. It configures the system hostname, serverName in server.conf and host in inputs.conf. All Splunk configuration changes are made using the ini_file module, which will preserve any other existing configurations that may exist in server.conf and/or inputs.conf.
 - **adhoc_decom_indexer.yml** - Executes a splunk offline --enforce-counts command. This is useful when decommissioning one or more indexers from an indexer cluster.

--- a/roles/splunk/tasks/adhoc_change_log_level.yml
+++ b/roles/splunk/tasks/adhoc_change_log_level.yml
@@ -1,0 +1,44 @@
+---
+- name: Change log level of {{ splunk_component }} to {{ splunk_component_log_level }} via CLI
+  ansible.builtin.command: |
+    {{ splunk_home }}/bin/splunk set log-level {{ splunk_component }} -level {{ splunk_component_log_level }} -auth '{{ splunk_auth }}'
+  register: log_level_chg_out
+  changed_when: log_level_chg_out.rc == 0
+  failed_when: log_level_chg_out.rc != 0
+  become: true
+  become_user: "{{ splunk_nix_user }}"
+  when:
+    - splunk_component is defined
+    - splunk_component_log_level is defined
+
+- name: Set log and log-local facts so we don't misspell them
+  ansible.builtin.set_fact:
+    splunk_log_cfg: "{{ splunk_home }}/etc/log.cfg"
+    splunk_log_local_cfg: "{{ splunk_home }}/etc/log-local.cfg"
+
+- name: Make sure log-local.cfg exists
+  ansible.builtin.stat:
+    path: "{{ splunk_log_local_cfg }}"
+  register: log_local_stat
+  become: true
+
+- name: Copy log to log-local if it doesn't exist
+  ansible.builtin.copy:
+    remote_src: true
+    src: "{{ splunk_log_cfg }}"
+    dest: "{{ splunk_log_local_cfg }}"
+    owner: "{{ splunk_nix_user }}"
+    group: "{{ splunk_nix_group }}"
+    mode: preserve
+  become: true
+  when: not log_local_stat.stat.exists
+
+- name: If it exists, add after splunkd stanza or change the log level and persist it in log-local.cfg
+  ansible.builtin.lineinfile:
+    path: "{{ splunk_log_local_cfg }}"
+    regexp: 'category.{{ splunk_component }}=[^,\s]+'
+    line: 'category.{{ splunk_component }}={{ splunk_component_log_level }}'
+    insertafter: '\[splunkd\]'
+  become: true
+  become_user: "{{ splunk_nix_user }}"
+  notify: restart splunk


### PR DESCRIPTION
# Summary

Changes the log-level at the CLI level, then makes sure `log-local.cfg` exists, and adds or modifies the the log level in there. Requires the variables `splunk_component` and `splunk_component_log_level` provided to the task.

## Modified files

- Added: `roles/tasks/adhoc_change_log_level.yml`
- Changed: `README.md`