### PR TITLE
install_apps: allow GET to run in check_mode

### DIFF
--- a/roles/splunk/tasks/install_apps.yml
+++ b/roles/splunk/tasks/install_apps.yml
@@ -53,6 +53,7 @@
         status_code: 200
         body:
           output_mode=json
+      check_mode: false
       no_log: true
       changed_when: false
       register: shc_status_response


### PR DESCRIPTION
Running GET is safe in check_mode.