### PR TITLE
add timeout var for reload deploy-server handler

### DIFF
--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -51,6 +51,7 @@ git_project: undefined
 git_version: master # Configure default version to clone, overridable inside the git_apps dictionary within host_vars
 app_relative_path: # set a sub-path you want to sync within a repo. If the repo contains multiple apps in the root directory, just set this to a trailing slash.
 splunk_app_deploy_path: undefined # Path under $SPLUNK_HOME/ to deploy apps to - Note that this may be set in group_vars, host_vars, playbook vars, or inside the git_apps dictionary within host_vars
+splunk_reload_deploy_server_timeout: 300  # Timeout in seconds the CLI waits for operation to complete before exiting
 # IDXC Vars
 splunk_idxc_key: mypass4symmkey
 splunk_idxc_rf: 2

--- a/roles/splunk/handlers/main.yml
+++ b/roles/splunk/handlers/main.yml
@@ -47,7 +47,7 @@
   when: "'clustermanager' in group_names"
 
 - name: reload deployment server
-  command: "{{ splunk_home }}/bin/splunk reload deploy-server -auth {{ splunk_auth }}"
+  command: "{{ splunk_home }}/bin/splunk reload deploy-server -timeout {{ splunk_reload_deploy_server_timeout }} -auth {{ splunk_auth }}"
   become: true
   become_user: "{{ splunk_nix_user }}"
   no_log: true


### PR DESCRIPTION
As environments grow the default timeout is too short causing the handler to incorrectly fail.

Setting initial default timeout to 300.
In our environment of ~5000 clients this has yet to timeout.