### PR TITLE
Correct Permissions for splunk.secret file

### DIFF
--- a/roles/splunk/tasks/configure_splunk_secret.yml
+++ b/roles/splunk/tasks/configure_splunk_secret.yml
@@ -1,10 +1,10 @@
 - name: Install splunk.secret
-  copy:
+  ansible.builtin.copy:
     src: "{{ splunk_secret_file }}"
     dest: "{{ splunk_home }}/etc/auth/splunk.secret"
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
-    mode: 0644
+    mode: 0400
   become: true
   notify: restart splunk
   when: splunk_configure_secret


### PR DESCRIPTION
The splunk.secret should only be readable by user.
This is the default permission on a splunk instance, too.