### PR TITLE
Creates local DMC dir if nonexistent

### DIFF
--- a/roles/splunk/tasks/configure_dmc.yml
+++ b/roles/splunk/tasks/configure_dmc.yml
@@ -14,6 +14,16 @@
   become_user: "{{ splunk_nix_user }}"
   no_log: true
 
+- name: Create local dir if it doesn't exist
+  ansible.builtin.file:
+    path: "{{ splunk_home }}/etc/apps/splunk_monitoring_console/local"
+    state: directory
+    owner: "{{ splunk_nix_user }}"
+    group: "{{ splunk_nix_group }}"
+    mode: 0744
+  become: true
+  become_user: "{{ splunk_nix_user }}"
+
 - name: Configure monitoring console in auto mode
   community.general.ini_file:
     path: "{{ splunk_home }}/etc/apps/splunk_monitoring_console/local/splunk_monitoring_console_assets.conf"


### PR DESCRIPTION
# Summary

Fixes an issue where the DMC is not automatically configured in Distributed mode because of the lack of the `local` directory referenced for the file `{{ splunk_home }}/etc/apps/splunk_monitoring_console/local/splunk_monitoring_console_assets.conf` in `configure_dmc.yml`. This fix makes sure the directory exists before creating the file, ensuring that the subsequent task doesn't fail.

## Changed

- [roles/splunk/tasks/configure_dmc.yml](roles/splunk/tasks/configure_dmc.yml)