### PR TITLE
Optimize permission set at install app phase

### DIFF
--- a/roles/splunk/tasks/install_apps.yml
+++ b/roles/splunk/tasks/install_apps.yml
@@ -91,8 +91,9 @@
 
 - name: Ensure correct permissions are set
   file:
-    path: "{{ splunk_home }}/{{ app_dest }}"
+    path: "{{ splunk_home }}/{{ app_dest }}/{{ item.name }}"
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
+    mode: "0750"
     recurse: true
   become: true


### PR DESCRIPTION
Changed the way we ensure correct permissions at `install_apps` tasks.
We don't need to change the permissions of the complete app directory, after every single app. To changing this to the just copied directory should be fine.
Additionally it is best practice to set a specific mode and the `others` don't need access.