### PR TITLE
decrypt secrets even in check_mode

### DIFF
--- a/roles/splunk/tasks/check_decrypted_secret.yml
+++ b/roles/splunk/tasks/check_decrypted_secret.yml
@@ -5,6 +5,7 @@
   become: true
   become_user: "{{ splunk_nix_user }}"
   changed_when: false
+  check_mode: false
   no_log: true
 
 - name: "Decrypt {{ req_secret_option }} of {{ req_secret_conf }}.conf [{{ req_secret_section }}]"
@@ -13,5 +14,6 @@
   become: true
   no_log: true
   changed_when: false
+  check_mode: false
   when:
     - encrypted_secret_value.rc == 0 and encrypted_secret_value.stdout != ""


### PR DESCRIPTION
to avoid false "changed" positives when running in check_mode we always need to extract and decrypt the secret