### PR TITLE
fix: 20-splunk.rules.j2 template variable

### DIFF
--- a/roles/splunk/templates/20-splunk.rules.j2
+++ b/roles/splunk/templates/20-splunk.rules.j2
@@ -1,2 +1,2 @@
--a never,exit -F path={{ splunk_home }}/bin/splunkd -F uid={{ ansible_facts.getent_passwd[splunk_user][1] }}
--a never,exit -F path={{ splunk_home }}/var/run/splunk -F uid={{ ansible_facts.getent_passwd[splunk_user][1] }}
+-a never,exit -F path={{ splunk_home }}/bin/splunkd -F uid={{ ansible_facts.getent_passwd[splunk_nix_user][1] }}
+-a never,exit -F path={{ splunk_home }}/var/run/splunk -F uid={{ ansible_facts.getent_passwd[splunk_nix_user][1] }}


### PR DESCRIPTION
Fixes https://github.com/splunk/ansible-role-for-splunk/pull/207 

Used incorrect variable name which caused "undefined variable" error. This corrects the variable name solving the issue.