### PR TITLE
Add ambientcapability to service for dmesg

### DIFF
--- a/roles/splunk/tasks/configure_systemd.yml
+++ b/roles/splunk/tasks/configure_systemd.yml
@@ -14,4 +14,6 @@
     - { option: "LimitDATA", value: "infinity" }
     - { option: "LimitCORE", value: "infinity" }
     - { option: "TasksMax", value: "infinity" }
+    # Add Option for CAP_SYSLOG to read dmesg even with dmesg_restrict active
+    - { option: "AmbientCapabilities", value: "CAP_SYSLOG"}
   notify: reload systemctl daemon


### PR DESCRIPTION
This change allows Splunk to read kernel log and use dmesg even with dmesg_restrict active. Therefore no need to activate for all non-root users