### PR TITLE
Fix undefined variable 'logrotate_file'

### DIFF
--- a/roles/splunk/tasks/configure_facl.yml
+++ b/roles/splunk/tasks/configure_facl.yml
@@ -22,7 +22,7 @@
 
     - name: Add setfacl to logrotate script
       lineinfile:
-        path: "{{ logrotate_file }}"
+        path: "{{ logrotate_file | default('/etc/logrotate.d/syslog') }}"
         insertbefore: 'endscript'
         line: '        /usr/bin/setfacl -Rm u:{{ splunk_nix_user }}:rx /var/log'
       become: True


### PR DESCRIPTION
Ran into an issue where the variable 'logrotate_file' was not set in one of the vars file (specifically [this](https://github.com/splunk/ansible-role-for-splunk/blob/master/roles/splunk/vars/RedHat8.yml) one) and thought it would be good to use a default value if it is not explicitly defined