### PR TITLE
added no_log to create user-seed task

### DIFF
--- a/roles/splunk/tasks/configure_user-seed.yml
+++ b/roles/splunk/tasks/configure_user-seed.yml
@@ -16,6 +16,7 @@
         group: "{{ splunk_nix_group }}"
         mode: 0644
       become: true
+      no_log: true
       when: not splunk_etc_passwd.stat.exists
   when:
     - splunk_admin_password != 'undefined'


### PR DESCRIPTION
currently user-seed creation task prints out the change in clear text which includes the admin password added no_log so it shouldn't print out 