### PR TITLE
Closes #230 added splunk_package_arch

### DIFF
--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -8,8 +8,9 @@ splunk_package_url: auto_determined # This gets set by main.yml but we have to d
 splunk_package_path: ~/
 splunk_package_version: 9.3.0 # The default version to install or update to. This can be set in `group_vars` or `host_vars`.
 build_id: 51ccf43db5bd # The default build to install or update to. This can be set in `group_vars` or `host_vars`.
-splunk_package_url_full: "https://download.splunk.com/products/splunk/releases/{{ splunk_package_version }}/linux/splunk-{{ splunk_package_version }}-{{ build_id }}-Linux-x86_64.tgz"
-splunk_package_url_uf: "https://download.splunk.com/products/universalforwarder/releases/{{ splunk_package_version }}/linux/splunkforwarder-{{ splunk_package_version }}-{{ build_id }}-Linux-x86_64.tgz"
+splunk_package_arch: "{{ splunk_package_version is version(9.4, '<') | ternary('Linux-x86_64', 'linux-amd64') }}"
+splunk_package_url_full: "https://download.splunk.com/products/splunk/releases/{{ splunk_package_version }}/linux/splunk-{{ splunk_package_version }}-{{ build_id }}-{{ splunk_package_arch }}.tgz"
+splunk_package_url_uf: "https://download.splunk.com/products/universalforwarder/releases/{{ splunk_package_version }}/linux/splunkforwarder-{{ splunk_package_version }}-{{ build_id }}-{{ splunk_package_arch }}.tgz"
 splunk_download_local: true  # This defines how the download process works. If `true` it will download to localhost and copy around to hosts from there. If `false` each host will download the package individually.
 splunk_install_type: undefined # There are two ways to configure this. The easiest way is to nest hosts under either a "full" group or a "uf" group in your inventory and main.yml will handle it for you. Or, you can also set the value via a group_vars or host_vars file.
 splunk_install_path: /opt # Base directory on the operating system to which splunk should be installed


### PR DESCRIPTION
The package naming convention changed in version 9.4.0.
[New_file_names_for_Splunk_Enterprise_and_Universal_Forwarder_software_packages](https://docs.splunk.com/Documentation/Splunk/9.4.0/Installation/AboutupgradingREADTHISFIRST#New_file_names_for_Splunk_Enterprise_and_Universal_Forwarder_software_packages)