### PR TITLE
fixed conpatibility with newer ansible version

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Third, ansible-role-for-splunk was designed to manage all Splunk configurations 
 
 ## Getting Started
 Getting started with this role will requires you to:
-1. Install Ansible (version >=v2.7 is supported and should work through v2.10)
+1. Install Ansible (version >=v2.10 is supported and should work through v2.19)
 1. Setup your inventory correctly
 1. Configure the appropriate variables to describe the desired state of your environment
 1. Create a playbook or leverage one of the included example playbooks that specifies the deployment_task you'd like to run

--- a/playbooks/splunk_install_or_upgrade.yml
+++ b/playbooks/splunk_install_or_upgrade.yml
@@ -6,4 +6,4 @@
     - ../roles/splunk
   serial: 50
   vars:
-    - deployment_task: check_splunk.yml
+    deployment_task: check_splunk.yml


### PR DESCRIPTION
Newer version of Ansible expect vars to be a dict.
```
ERROR! Vars in a Play must be specified as a dictionary.
```