### PR TITLE
option to customize splunk linux home directory

### DIFF
--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -4,6 +4,7 @@
 slack_channel: undefined
 slack_token: undefined
 splunk_home: auto_determined  # This gets set by main.yml but we have to define it here or Ansible will complain that it is undefined
+splunk_nix_home: "{{ splunk_home }}" # This is the Linux home directory for the splunk user as set in /etc/passwd. It is set to the same value as splunk_home by default.
 splunk_package_url: auto_determined  # This gets set by main.yml but we have to define it here or Ansible will complain that it is undefined
 splunk_package_path: ~/
 splunk_package_version: 9.4.2 # The default version to install or update to. This can be set in `group_vars` or `host_vars`.

--- a/roles/splunk/tasks/configure_bash.yml
+++ b/roles/splunk/tasks/configure_bash.yml
@@ -2,7 +2,7 @@
 - name: Install .bashrc and .bash_profile files
   ansible.builtin.template:
     src: "{{ item.bashtemplate }}"
-    dest: "{{ splunk_home }}/{{ item.bashfilepath }}"
+    dest: "{{ splunk_nix_home }}/{{ item.bashfilepath }}"
     owner: "{{ splunk_nix_user }}"
     group: "{{ splunk_nix_group }}"
     mode: "0644"

--- a/roles/splunk/tasks/install_splunk.yml
+++ b/roles/splunk/tasks/install_splunk.yml
@@ -16,7 +16,7 @@
       ansible.builtin.user:
         name: "{{ splunk_nix_user }}"
         group: "{{ splunk_nix_group }}"
-        home: "{{ splunk_home }}"
+        home: "{{ splunk_nix_home }}"
         state: present
         shell: /bin/bash
         local: "{{ local_os_user }}"


### PR DESCRIPTION
In some cases, systems may already have the splunk user configured, but with a different system home directory in `/etc/passwd`. In those cases, the `install_splunk.yml` task may fail when using the `splunk` user as the `ansible_user`, or if a user wants to keep the linux home directory separate from the `splunk_home`.