### PR TITLE
add splunk_nix_user to additional groups if defined

### DIFF
--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -18,6 +18,7 @@ splunk_install_path: /opt  # Base directory on the operating system to which spl
 least_privileged: false  # Do not change. This get automatically set in `tasks/main.yml` based on the version and install type.
 splunk_nix_user: splunk
 splunk_nix_group: splunk
+# splunk_nix_groups: "group1,group2" # Uncomment and add a comma separated list of groups if you want to add the splunk_nix_user to additional groups. Uncomment and leave empty if you want to remove splunk from all additional groups. This can also be set in group_vars or host_vars.
 local_os_user: false  # Whenther or not to force creation of a user using the `luseradd` or not.
 local_os_group: false  # Whether or not to force creation of a group using the `lgroupadd` or not.
 splunk_uri_lm: undefined

--- a/roles/splunk/tasks/install_splunk.yml
+++ b/roles/splunk/tasks/install_splunk.yml
@@ -16,10 +16,12 @@
       ansible.builtin.user:
         name: "{{ splunk_nix_user }}"
         group: "{{ splunk_nix_group }}"
+        groups: "{{ splunk_nix_groups | default(omit) }}"
         home: "{{ splunk_nix_home }}"
         state: present
         shell: /bin/bash
         local: "{{ local_os_user }}"
+        append: "{{ true if (splunk_nix_groups | default([]) | length > 0) else omit }}"
       become: true
 
     - name: Allow splunk user to read /var/log


### PR DESCRIPTION
This allows adding the `splunk_nix_user` to additional groups