### PR TITLE
new splunkupgrader role for remote upgrader service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 environments/test
 roles/splunk/files/*.lic
+roles/splunkupgrader/files/splunk-upgrader-linux-*.tgz

--- a/playbooks/splunkupgrader_install.yml
+++ b/playbooks/splunkupgrader_install.yml
@@ -1,0 +1,6 @@
+---
+# Example playbook to perform either a splunk installation or upgrade
+- hosts: all
+  roles:
+    - ../roles/splunkupgrader
+  serial: 50

--- a/roles/splunkupgrader/README.md
+++ b/roles/splunkupgrader/README.md
@@ -1,0 +1,174 @@
+# Splunk Upgrader Role
+
+This Ansible role installs and configures the Splunk Remote Upgrader utility, which enables remote upgrading of Splunk Universal Forwarders across your infrastructure.
+
+## Description
+
+The Splunk Remote Upgrader is a utility that allows administrators to centrally manage and upgrade Splunk Universal Forwarders without manual intervention on each host. This role automates the installation and configuration of the upgrader daemon on target systems.
+
+## Requirements
+
+- Ansible 2.9 or higher
+- Target systems must be Linux-based
+- Root privileges on target systems
+- **Splunk Remote Upgrader package**: Must be downloaded from [Splunk's official site](https://help.splunk.com/en/splunk-enterprise/forward-and-process-data/splunk-remote-upgrader-for-linux-universal-forwarders/10.0/installation/download-your-remote-upgrader) and placed in the `files/` directory
+
+## Role Variables
+
+### Default Variables
+
+The following variables can be overridden in your playbooks or inventory:
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+| `upgrader_version` | `102` | Version of the Splunk Upgrader to install |
+| `SPLUNK_UPDATER_USER` | `splunkupgrader` | Username for the upgrader service |
+| `SPLUNK_UPDATER_GROUP` | `splunkupgrader` | Group name for the upgrader service |
+| `MONITOR_PKG_INTERVAL_SEC` | `5` | Package monitoring interval in seconds (5-300) |
+| `FWD_UPGRADE_TIMEOUT_SEC` | `300` | Forwarder upgrade timeout in seconds (60-600) |
+| `FWD_UPGRADE_MAX_RETRY` | `3` | Maximum retry attempts for upgrade |
+| `ROTATE_HISTORY_LOG_DAYS` | `30` | Number of days to retain history logs (0-360) |
+| `upgrader_package_file` | `splunk-upgrader-linux-{{ upgrader_version }}.tgz` | Name of the upgrader package file |
+| `upgrader_package_dest` | `/tmp/` | Destination directory for package extraction |
+| `upgrader_install_base` | `/opt/` | Base installation directory |
+| `upgrader_install_path` | `{{ upgrader_install_base }}splunkupgrader/` | Full installation path |
+
+## Dependencies
+
+None
+
+## Example Playbook
+
+### Basic Usage
+
+```yaml
+---
+- hosts: splunk_forwarders
+  become: yes
+  roles:
+    - splunkupgrader
+```
+
+### Custom Configuration
+
+```yaml
+---
+- hosts: splunk_forwarders
+  become: yes
+  vars:
+    upgrader_version: 102
+    SPLUNK_UPDATER_USER: custom_upgrader
+    MONITOR_PKG_INTERVAL_SEC: 10
+    FWD_UPGRADE_TIMEOUT_SEC: 600
+  roles:
+    - splunkupgrader
+```
+
+### Using with Serial Execution
+
+```yaml
+---
+- hosts: splunk_forwarders
+  become: yes
+  serial: 50  # Process 50 hosts at a time
+  roles:
+    - splunkupgrader
+```
+
+## What This Role Does
+
+1. **Package Deployment**: Extracts the Splunk Upgrader package to the target system
+2. **Configuration**: Creates a customized configuration file based on your variables
+3. **Installation**: Runs the upgrader installation script with license acceptance
+   - The installation script automatically creates a systemd service for the upgrader daemon
+   - The installation script automatically creates the upgrader user and group as specified
+
+## Required Files
+
+### Splunk Remote Upgrader Package
+
+This role requires the Splunk Remote Upgrader package, which must be downloaded separately from Splunk's official website:
+
+1. **Download Location**: Visit [Splunk's Remote Upgrader download page](https://help.splunk.com/en/splunk-enterprise/forward-and-process-data/splunk-remote-upgrader-for-linux-universal-forwarders/10.0/installation/download-your-remote-upgrader)
+2. **Package Name**: Download `splunk-remote-upgrader-for-linux-universal-forwarders_102.tgz`
+3. **Extract and Place**:
+   - Extract the downloaded archive
+   - Navigate to `default/packages/` within the extracted content
+   - Copy `splunk-upgrader-linux-102.tgz` (or the version specified by `upgrader_version`) to the `files/` directory of this role
+
+**Note**: The package is not included in this repository due to licensing restrictions. You must download it directly from Splunk.
+
+### Files Included in This Role
+
+- `templates/local_config_102.j2` - Configuration template for the upgrader
+
+## Post-Installation
+
+After running this role, the Splunk Remote Upgrader will be:
+
+- Installed in `/opt/splunkupgrader/` (by default)
+- Running as a systemd service (`splunk-upgrader.service`)
+- Configured with your specified parameters
+- Ready to monitor for upgrade packages and perform remote upgrades
+
+### Service Management
+
+```bash
+# Check service status
+sudo systemctl status splunk-upgrader
+
+# Start/stop the service
+sudo systemctl start splunk-upgrader
+sudo systemctl stop splunk-upgrader
+
+# View logs
+sudo journalctl -u splunk-upgrader -f
+```
+
+### Configuration Updates
+
+To modify the upgrader configuration after installation:
+
+1. Edit `/opt/splunkupgrader/config/local_config`
+2. Restart the service: `sudo systemctl restart splunk-upgrader`
+
+## Security Considerations
+
+- The upgrader runs with the permissions of the configured user/group
+- Installation requires root privileges
+- Configuration files contain sensitive settings that should be managed carefully
+- The upgrader monitors `/tmp/SPLUNK_UPDATER_MONITORED_DIR` for packages by default
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Permission Errors**: Ensure the role is run with `become: yes`
+2. **Service Won't Start**: Check systemd logs with `journalctl -u splunk-upgrader`
+3. **Package Not Found**:
+   - Verify the upgrader package file exists in the `files/` directory
+   - Download `splunk-remote-upgrader-for-linux-universal-forwarders_102.tgz` from [Splunk's official site](https://help.splunk.com/en/splunk-enterprise/forward-and-process-data/splunk-remote-upgrader-for-linux-universal-forwarders/10.0/installation/download-your-remote-upgrader)
+   - Extract the downloaded file and copy `splunk-upgrader-linux-102.tgz` from `default/packages/` to the role's `files/` directory
+   - Ensure the filename matches the `upgrader_package_file` variable
+4. **Configuration Errors**: Review `/opt/splunkupgrader/config/local_config`
+
+### Log Locations
+
+- Service logs: `journalctl -u splunk-upgrader`
+- Upgrader logs: `/opt/splunkupgrader/log/`
+
+## License
+
+See the main repository LICENSE file.
+
+## Author Information
+
+This role is part of the ansible-role-for-splunk project.
+
+## Contributing
+
+Please refer to the main repository for contribution guidelines.
+
+---
+
+For more information about the Splunk Remote Upgrader utility, consult the official Splunk documentation.

--- a/roles/splunkupgrader/defaults/main.yml
+++ b/roles/splunkupgrader/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+upgrader_version: 102
+SPLUNK_UPDATER_USER: splunkupgrader
+SPLUNK_UPDATER_GROUP: splunkupgrader
+MONITOR_PKG_INTERVAL_SEC: 5
+FWD_UPGRADE_TIMEOUT_SEC: 300
+FWD_UPGRADE_MAX_RETRY: 3
+ROTATE_HISTORY_LOG_DAYS: 30
+upgrader_package_file: splunk-upgrader-linux-{{ upgrader_version }}.tgz
+upgrader_package_dest: /tmp/
+upgrader_install_base: /opt/
+upgrader_install_path: "{{ upgrader_install_base }}splunkupgrader/"

--- a/roles/splunkupgrader/tasks/check_package.yml
+++ b/roles/splunkupgrader/tasks/check_package.yml
@@ -1,0 +1,26 @@
+---
+- name: Check if splunkupgrader is already installed
+  ansible.builtin.stat:
+    path: "{{ upgrader_install_path }}"
+  register: splunkupgrader_installed
+
+- name: Check splunkupgrader version
+  ansible.builtin.slurp:
+    src: "{{ upgrader_install_path }}/VERSION"
+  register: installed_version_file
+  when: splunkupgrader_installed.stat.exists
+
+- name: Set installed version fact
+  ansible.builtin.set_fact:
+    installed_upgrader_version: "{{ installed_version_file['content'] | b64decode | trim | replace('.', '') }}"
+  when: splunkupgrader_installed.stat.exists
+
+- name: Print installation status - Not Installed
+  ansible.builtin.debug:
+    msg: "Splunk Upgrader is NOT installed at {{ upgrader_install_path }}"
+  when: not splunkupgrader_installed.stat.exists
+
+- name: Print installation status - Installed
+  ansible.builtin.debug:
+    msg: "Splunk Upgrader is installed at {{ upgrader_install_path }} - Version: {{ installed_upgrader_version }}"
+  when: splunkupgrader_installed.stat.exists

--- a/roles/splunkupgrader/tasks/check_service.yml
+++ b/roles/splunkupgrader/tasks/check_service.yml
@@ -1,0 +1,7 @@
+---
+- name: Check if splunkupgrader service is running
+  ansible.builtin.systemd:
+    name: splunk-upgrader
+    state: started
+  register: splunkupgrader_service_status
+  ignore_errors: true

--- a/roles/splunkupgrader/tasks/install_upgrader.yml
+++ b/roles/splunkupgrader/tasks/install_upgrader.yml
@@ -1,0 +1,28 @@
+---
+- name: Copy splunkupgrader app to target
+  ansible.builtin.unarchive:
+    src: "{{ upgrader_package_file }}"
+    dest: "{{ upgrader_install_base }}"
+    owner: root
+    group: root
+    mode: '0755'
+  become: true
+  become_user: root
+
+- name: Copy config template for splunkupgrader
+  ansible.builtin.template:
+    src: "local_config_{{ upgrader_version }}.j2"
+    dest: "{{ upgrader_install_path }}/config/local_config"
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+  become_user: root
+
+- name: Install splunkupgrader
+  ansible.builtin.command:
+    cmd: "{{ upgrader_install_path }}/bin/install.sh --accept-license --create-user"
+  become: true
+  become_user: root
+  args:
+    creates: /etc/systemd/system/splunk-upgrader.service

--- a/roles/splunkupgrader/tasks/main.yml
+++ b/roles/splunkupgrader/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Check if splunkupgrader is already installed
+  ansible.builtin.include_tasks: check_package.yml
+
+- name: Install splunkupgrader if not installed or version mismatch
+  ansible.builtin.include_tasks: install_upgrader.yml
+  when: not splunkupgrader_installed.stat.exists or installed_upgrader_version != upgrader_version

--- a/roles/splunkupgrader/tasks/main.yml
+++ b/roles/splunkupgrader/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Check if instance is a Universal Forwarder
+  ansible.builtin.fail:
+    msg: "splunkupgrader role can only be applied to Universal Forwarder instances (splunk_install_type must be 'uf'). Current type: {{ splunk_install_type | default('undefined') }}"
+  when: splunk_install_type != "uf"
+
 - name: Check if splunkupgrader is already installed
   ansible.builtin.include_tasks: check_package.yml
 

--- a/roles/splunkupgrader/templates/local_config_102.j2
+++ b/roles/splunkupgrader/templates/local_config_102.j2
@@ -1,0 +1,45 @@
+# Splunk Remote Upgrader configurations
+
+# *DO NOT* update this file. Copy and create another "local_config" file
+# in the same folder, and customize configurations there. This file will
+# be overwritten once the Upgrader daemon upgrades, so all customized changes 
+# on this file will be missing.
+
+# Should add validation rules for each configurations in ./bin/load_config_file.sh
+
+# ============= Configurations from Upgrader owner only ===========
+# NOTE: these are sensitive configurations, which should be managed by System admin only!
+
+# To customize these configuration, System admin should:
+# 1. Login each box where Upgrader installed
+# 2. Go to the Upgrader ./config dir, create a local_config file
+# 3. Copy these configurations to the local_config, update values
+# 4. Restart the Upgrader daemon
+
+# Installation only configurations. Update them before executing ./install.sh if needed,
+# and leave them in the local_config. Update them after installation will not change 
+# anything since the Upgrader has been configured and running as this user & group.
+SPLUNK_UPDATER_USER={{ SPLUNK_UPDATER_USER }}    # default name if pre-created user is not provided
+SPLUNK_UPDATER_GROUP={{ SPLUNK_UPDATER_GROUP }}   # default name if pre-created user is not provided
+
+# ============= Configurations from anyone ===========
+# Both System admin and Splunk admin can update these configurations.
+
+# System admin can follow exactly same steps mentioned in above section.
+
+# Splunk admin can either put their own local_config file into the delivery app, 
+# and push the app from Deployment Server to UF, or just put the file directly to
+# the "/tmp/SPLUNK_UPDATER_MONITORED_DIR". And then the Upgrader picks it up, validate
+# it and apply it.
+
+# DO NOT set SPLUNK_HOME from monitored dir, unless Upgrader is running as ROOT,
+# otherwise Splunk cannot start after upgrade due to lack of permissions for
+# the new SPLUNK_HOME
+
+# SPLUNK_HOME=<path-to-splunk-home-dir>
+
+MONITOR_PKG_INTERVAL_SEC={{ MONITOR_PKG_INTERVAL_SEC }}    # range [5, 300]
+FWD_UPGRADE_TIMEOUT_SEC={{ FWD_UPGRADE_TIMEOUT_SEC }}   # range [60, 600]
+FWD_UPGRADE_MAX_RETRY={{ FWD_UPGRADE_MAX_RETRY }}
+ROTATE_HISTORY_LOG_DAYS={{ ROTATE_HISTORY_LOG_DAYS }}    # range [0, 360]
+


### PR DESCRIPTION
The `splunkupgrader` roles installs and configures  the **Splunk Remote Upgrader for Linux Universal Forwarders** service that allows you to remotely upgrade Universal Forwarders. See docs [here](https://help.splunk.com/en/splunk-enterprise/forward-and-process-data/splunk-remote-upgrader-for-linux-universal-forwarders/10.0/about-the-splunk-remote-upgrader-for-linux-universal-forwarders/about-the-splunk-remote-upgrader-for-linux-universal-forwarders) for installation instructions and more details.

This roles copies over the package and runs the install script, it does not configure the serverclass on the Deployment Server. More information on how to use this service see docs [here](https://help.splunk.com/en/splunk-enterprise/forward-and-process-data/splunk-remote-upgrader-for-linux-universal-forwarders/10.0/configure/work-with-signature-validation-files-for-upgrading).
