### PR TITLE
Fix version regex to support double-digit major versions

### DIFF
--- a/roles/splunk/tasks/check_splunk_version.yml
+++ b/roles/splunk/tasks/check_splunk_version.yml
@@ -9,4 +9,4 @@
 
 - name: Get Splunk version number only
   ansible.builtin.set_fact:
-    splunk_version_release: "{{ current_version.stdout | regex_search('(\\d\\.\\d+\\.[^\\s]+)') }}"
+    splunk_version_release: "{{ current_version.stdout | regex_search('(\\d+\\.\\d+\\.[^\\s]+)') }}"


### PR DESCRIPTION
## Summary
- Fixes version detection regex to support Splunk 10.x releases
- Changed pattern from `\d\.\d+` to `\d+\.\d+` to match one or more digits in the major version component

## Problem
The current regex `(\d\.\d+\.[^\s]+)` only matches single-digit major versions. When checking version `10.0.1`, it incorrectly extracts `0.0.1` instead of `10.0.1`, causing unnecessary reinstallation attempts.

## Solution  
Updated the regex to `(\d+\.\d+\.[^\s]+)` which correctly matches both single-digit (9.x.x) and double-digit (10.x.x) major versions.

## Testing
The fix correctly extracts version numbers for both:
- Splunk 9.x.x releases (backward compatible)
- Splunk 10.x.x releases (new support)