### PR TITLE
fix debian 13 boot start error: version OPENSSL_3.4.0 not found

### DIFF
--- a/roles/splunk/tasks/configure_splunk_boot.yml
+++ b/roles/splunk/tasks/configure_splunk_boot.yml
@@ -28,7 +28,9 @@
     - name: Disable boot-start if it needs to be to reconfigured
       ansible.builtin.command: "{{ splunk_home }}/bin/splunk disable boot-start"
       become: true
+      register: splunk_bootstart_disabled
       when: current_start_method is defined or splunk_upgraded is defined
+      failed_when: splunk_bootstart_disabled.rc not in [0, 8]
 
     - name: Ensure init.d file is really gone
       ansible.builtin.file:
@@ -55,8 +57,10 @@
     - name: Enable splunk boot-start via systemd
       ansible.builtin.command: "{{ splunk_home }}/bin/splunk enable boot-start -user {{ splunk_nix_user }} -group {{ splunk_nix_group }} -systemd-managed 1 -systemd-unit-file-name {{ systemd_unit }} -create-polkit-rules {{ splunk_create_polkit }} --answer-yes --auto-ports --no-prompt --accept-license"
       become: true
+      register: splunk_bootstart_enabled
       when:
         - desired_start_method == "systemd"
+      failed_when: splunk_bootstart_enabled.rc not in [0, 8]
       notify:
         - reload systemctl daemon
         - start splunk

--- a/roles/splunk/tasks/remove_splunk.yml
+++ b/roles/splunk/tasks/remove_splunk.yml
@@ -3,6 +3,8 @@
 
 - name: Disable boot-start
   ansible.builtin.command: "{{ splunk_home }}/bin/splunk disable boot-start"
+  register: splunk_bootstart_disabled
+  failed_when: splunk_bootstart_disabled.rc not in [0, 8]
   become: true
 
 - name: Remove splunk folder


### PR DESCRIPTION
When installing version 10.0.2 on Debian 13, the role throws the following error whenever enabling or disabling boot-start:
```
systemctl: /opt/splunk/lib/libcrypto.so.3: version `OPENSSL_3.4.0' not found (required by /usr/lib/x86_64-linux-gnu/systemd/libsystemd-shared-257.so)
systemctl: /opt/splunk/lib/libcrypto.so.3: version `OPENSSL_3.4.0' not found (required by /usr/lib/x86_64-linux-gnu/systemd/libsystemd-shared-257.so)
```
The actual exit status is `8` and the boot is actually configured correctly, but since it's not `0`, the task fails.

The current solution is to limit that task failure when it's not `0` or `8`.