### PR TITLE
Fix version comparison skipping upgrade when installed version < 10

### DIFF
--- a/roles/splunk/tasks/check_splunk.yml
+++ b/roles/splunk/tasks/check_splunk.yml
@@ -46,6 +46,6 @@
         - name: Upgrade Splunk if not at expected version
           ansible.builtin.include_tasks: upgrade_splunk.yml
       # Conditional for version mismatch block
-      when: splunk_version_release < splunk_package_version
+      when: splunk_version_release is version(splunk_package_version, '<')
   # Conditional for this block
   when: splunkd_path.stat.exists == true


### PR DESCRIPTION
The version mismatch condition in `check_splunk.yml` used a plain string comparison (`<`) to decide whether to upgrade. this caused the upgrade block to be skipped when the installed version was 9.x and the target was 10.x, because lexicographic comparison treats "9" > "1".