### PR TITLE
fix IDXC rolling upgrade play targets and add features

### DIFF
--- a/playbooks/splunk_idxc_rolling_upgrade.yml
+++ b/playbooks/splunk_idxc_rolling_upgrade.yml
@@ -11,6 +11,8 @@
 # Optional Variables:
 #   - idxc_serial: Batch size for peer upgrades (default: 1).
 #                  Accepts integer or percentage (e.g., "20%").
+#   - remove_excess_buckets: Remove excess bucket copies after upgrade (default: false).
+#                            Pass -e remove_excess_buckets=true to enable.
 #
 # Usage:
 #   ansible-playbook playbooks/splunk_idxc_rolling_upgrade.yml
@@ -153,3 +155,15 @@
           - _cm_health.pre_flight_check | default(false) | bool
           - not (_cm_status.rolling_restart_flag | default(false) | bool)
         fail_msg: "Post-upgrade cluster health check failed."
+
+# Play 8 - Remove excess bucket copies (optional, requires -e remove_excess_buckets=true)
+- hosts:
+    - clustermanager
+  become: true
+  any_errors_fatal: true
+  max_fail_percentage: 0
+  roles:
+    - ../roles/splunk
+  vars:
+    deployment_task: splunk_idx/cm_prune_excess_buckets.yml
+  when: remove_excess_buckets | default(false) | bool

--- a/playbooks/splunk_idxc_rolling_upgrade.yml
+++ b/playbooks/splunk_idxc_rolling_upgrade.yml
@@ -3,38 +3,19 @@
 # Upgrades peers in batches (serial: idxc_serial, default 1) with health check gates.
 #
 # Prerequisites:
-#   - splunk_uri_cm, splunk_admin_username, splunk_admin_password must be set
+#   - splunk_admin_username, splunk_admin_password must be set
+#   - splunk_uri_cm must be set for the 'indexer' group (CM plays derive it automatically)
 #   - Inventory must have 'clustermanager' and 'indexer' groups
 #   - splunk_package_version and build_id must be set to the target version
+#
+# Optional Variables:
+#   - idxc_serial: Batch size for peer upgrades (default: 1).
+#                  Accepts integer or percentage (e.g., "20%").
 #
 # Usage:
 #   ansible-playbook playbooks/splunk_idxc_rolling_upgrade.yml
 
-# Play 1 - Pre-upgrade health check
-- hosts:
-    - indexer
-  become: true
-  any_errors_fatal: true
-  max_fail_percentage: 0
-  roles:
-    - ../roles/splunk
-  vars:
-    deployment_task: splunk_idx/check_cluster_health.yml
-    cm_check_status: true
-  post_tasks:
-    - name: Assert cluster is ready for upgrade
-      ansible.builtin.assert:
-        that:
-          - splunk_cm_reachable | bool
-          - _cm_health.pre_flight_check | default(false) | bool
-          - not (_cm_status.maintenance_mode | default(false) | bool)
-          - not (_cm_status.rolling_restart_flag | default(false) | bool)
-        fail_msg: "Pre-upgrade cluster health check failed. Aborting."
-
-    - name: Collect peer GUIDs
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/../roles/splunk/tasks/splunk_common/server_info.yml"
-
-# Play 2 - rolling_upgrade_init
+# Play 1 - Upgrade cluster manager
 - hosts:
     - clustermanager
   become: true
@@ -43,16 +24,76 @@
   roles:
     - ../roles/splunk
   vars:
+    deployment_task: check_splunk.yml
+  post_tasks:
+    - name: Wait for splunkd to be ready
+      ansible.builtin.wait_for:
+        host: "{{ splunk_mgmt_uri }}"
+        port: "{{ splunkd_port }}"
+        timeout: 300
+
+# Play 2 - Collect peer GUIDs from all indexers (any failure aborts the playbook)
+- hosts:
+    - indexer
+  become: true
+  any_errors_fatal: true
+  max_fail_percentage: 0
+  roles:
+    - ../roles/splunk
+  vars:
+    deployment_task: splunk_common/server_info.yml
+
+# Play 3 - Pre-upgrade cluster health check (CM only)
+- hosts:
+    - clustermanager
+  become: true
+  any_errors_fatal: true
+  max_fail_percentage: 0
+  roles:
+    - ../roles/splunk
+  vars:
+    splunk_uri_cm: "https://{{ splunk_mgmt_uri }}:{{ splunkd_port }}"
+    deployment_task: splunk_idx/check_cluster_health.yml
+    cm_check_status: true
+  post_tasks:
+    - name: Assert cluster is ready for upgrade
+      ansible.builtin.assert:
+        that:
+          - splunk_cm_reachable | bool
+          - _cm_health.pre_flight_check | default(false) | bool
+          - not (_cm_status.rolling_restart_flag | default(false) | bool)
+        fail_msg: "Pre-upgrade cluster health check failed. Aborting."
+
+# Play 4 - Signal CM to begin rolling upgrade (sets ru_state: init)
+- hosts:
+    - clustermanager
+  become: true
+  any_errors_fatal: true
+  max_fail_percentage: 0
+  roles:
+    - ../roles/splunk
+  vars:
+    splunk_uri_cm: "https://{{ splunk_mgmt_uri }}:{{ splunkd_port }}"
     deployment_task: splunk_idx/cm_rolling_upgrade.yml
     ru_state: init
 
-# Play 3 - Upgrade indexers in batches
+# Play 5 - Upgrade indexers in batches
 - hosts:
     - indexer
   serial: "{{ idxc_serial | default(1) }}"
   become: true
   any_errors_fatal: true
   max_fail_percentage: 0
+  pre_tasks:
+    - name: Assert peer GUIDs were collected
+      ansible.builtin.assert:
+        that:
+          - hostvars[inventory_hostname]._server_info is defined
+          - hostvars[inventory_hostname]._server_info.guid is defined
+        fail_msg: >-
+          _server_info.guid is not defined for {{ inventory_hostname }}.
+          Play 2 (server_info collection) must complete before Play 5.
+          Do not use --start-at-task to skip Play 1.
   roles:
     - ../roles/splunk
   vars:
@@ -79,7 +120,7 @@
           - splunk_cm_reachable | bool
         fail_msg: "CM became unreachable during peer polling. Aborting upgrade."
 
-# Play 4 - rolling_upgrade_finalize
+# Play 6 - Signal CM to finalize rolling upgrade (sets ru_state: finalize)
 - hosts:
     - clustermanager
   become: true
@@ -88,18 +129,20 @@
   roles:
     - ../roles/splunk
   vars:
+    splunk_uri_cm: "https://{{ splunk_mgmt_uri }}:{{ splunkd_port }}"
     deployment_task: splunk_idx/cm_rolling_upgrade.yml
     ru_state: finalize
 
-# Play 5 - Post-upgrade health check
+# Play 7 - Post-upgrade health check (CM only)
 - hosts:
-    - indexer
+    - clustermanager
   become: true
   any_errors_fatal: true
   max_fail_percentage: 0
   roles:
     - ../roles/splunk
   vars:
+    splunk_uri_cm: "https://{{ splunk_mgmt_uri }}:{{ splunkd_port }}"
     deployment_task: splunk_idx/check_cluster_health.yml
     cm_check_status: true
   post_tasks:

--- a/playbooks/splunk_idxc_rolling_upgrade.yml
+++ b/playbooks/splunk_idxc_rolling_upgrade.yml
@@ -95,7 +95,7 @@
         fail_msg: >-
           _server_info.guid is not defined for {{ inventory_hostname }}.
           Play 2 (server_info collection) must complete before Play 5.
-          Do not use --start-at-task to skip Play 1.
+          Do not use --start-at-task to skip Play 2.
   roles:
     - ../roles/splunk
   vars:
@@ -162,8 +162,11 @@
   become: true
   any_errors_fatal: true
   max_fail_percentage: 0
+  pre_tasks:
+    - name: Skip if remove_excess_buckets is not set
+      ansible.builtin.meta: end_play
+      when: not (remove_excess_buckets | default(false) | bool)
   roles:
     - ../roles/splunk
   vars:
     deployment_task: splunk_idx/cm_prune_excess_buckets.yml
-  when: remove_excess_buckets | default(false) | bool

--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -1,6 +1,12 @@
 ---
 # defaults file for splunk role
 # Anything that is undefined here should be configured. I recommend setting the values in your group_vars under an all.yml file.
+#
+# BREAKING CHANGE: ansible_python_interpreter is now set to /usr/bin/python3 by default.
+# Splunk 10.2+ ships an embedded Python 3.13 that is missing standard library modules
+# (e.g. grp), causing Ansible module execution failures when auto-discovered.
+# Override this in group_vars or host_vars if your system Python is in a different path.
+ansible_python_interpreter: /usr/bin/python3
 slack_channel: undefined
 slack_token: undefined
 splunk_home: auto_determined  # This gets set by main.yml but we have to define it here or Ansible will complain that it is undefined

--- a/roles/splunk/tasks/splunk_idx/cm_prune_excess_buckets.yml
+++ b/roles/splunk/tasks/splunk_idx/cm_prune_excess_buckets.yml
@@ -1,0 +1,13 @@
+---
+- name: Remove excess bucket copies from cluster
+  ansible.builtin.uri:
+    url: "https://{{ splunk_mgmt_uri }}:{{ splunkd_port }}/services/cluster/manager/control/control/prune_index"
+    method: POST
+    user: "{{ splunk_admin_username }}"
+    password: "{{ splunk_admin_password }}"
+    force_basic_auth: true
+    validate_certs: "{{ splunk_validate_certs | default(false) }}"
+    status_code: 200
+  no_log: true
+  changed_when: true
+  when: "'clustermanager' in group_names"


### PR DESCRIPTION
## Summary

Fixes play targeting and structure in the IDXC rolling upgrade playbook (#255), and adds a role-wide fix for Splunk 10.2+ Python discovery:

- **Added CM upgrade as Play 1** - per Splunk upgrade order, the cluster manager must be upgraded before indexer peers
- **Split GUID collection into its own play** (Play 2) so `server_info` runs on indexers and CM health checks run only on the CM
- **Re-targeted pre- and post-upgrade health checks to `clustermanager`** - `check_cluster_health.yml` queries CM REST endpoints, so running it on every indexer just executes the same API call N times
- **Derived `splunk_uri_cm` for CM plays** using `splunk_mgmt_uri` and `splunkd_port`, so the CM doesn't need `splunk_uri_cm` in inventory
- **Removed `maintenance_mode` pre-upgrade assertion** - per Splunk docs, `upgrade-init` and `upgrade-finalize` manage maintenance mode automatically
- **Added `pre_tasks` assert in Play 5** to guard against `--start-at-task` skipping GUID collection
- **Documented `idxc_serial` variable** in playbook header
- **Added optional excess bucket pruning** (Play 8) via `-e remove_excess_buckets=true`, calls the CM `prune_index` API

### Breaking change: `ansible_python_interpreter`

`ansible_python_interpreter` is now set to `/usr/bin/python3` in role defaults. Splunk 10.2+ ships an embedded Python 3.13 missing standard library modules (e.g. `grp`), causing Ansible to fail when it auto-discovers `/opt/splunk/bin/python3.13`. Override in `group_vars` or `host_vars` if your system Python is in a different path.

## Play structure (after)

| Play | Target | Purpose |
|------|--------|---------|
| 1 | `clustermanager` | Upgrade CM, wait for splunkd |
| 2 | `indexer` | Collect peer GUIDs (fail-fast if any indexer unreachable) |
| 3 | `clustermanager` | Pre-upgrade cluster health check |
| 4 | `clustermanager` | `upgrade-init` (enables maintenance mode) |
| 5 | `indexer` (serial) | Upgrade indexers in batches, poll CM for peer rejoin |
| 6 | `clustermanager` | `upgrade-finalize` (disables maintenance mode) |
| 7 | `clustermanager` | Post-upgrade cluster health check |
| 8 | `clustermanager` | Remove excess bucket copies (optional) |

## Note for reviewers

The following were considered and intentionally left as-is:

- **Post-upgrade check targets CM, not indexers** - `check_cluster_health.yml` only queries CM REST endpoints; per-indexer health is validated by Play 2 (GUID collection with `any_errors_fatal`) and Play 5's per-batch CM polling
- **TLS cert validation disabled by default** - pre-existing behavior across the entire role; most Splunk environments use self-signed certificates
- **No `maintenance_mode` assertion in post-upgrade check** - `upgrade-finalize` automatically disables it, so asserting it off is testing Splunk's own API contract
- **`ru_state` interpolated into REST URL without validation** - pre-existing; values are hardcoded literals in the playbook, not derived from user input
- **`become: true` without explicit `become_user`** - pre-existing convention across all playbooks; root is Ansible's default
- **Dual task invocation patterns (role dispatcher vs `include_tasks`)** - by design; Play 5 needs per-batch variables from `ansible_play_batch` which the role dispatcher can't provide