### PR TITLE
Fix mixed install type download (#176)

### DIFF
--- a/roles/splunk/tasks/download_and_unarchive.yml
+++ b/roles/splunk/tasks/download_and_unarchive.yml
@@ -18,7 +18,7 @@
   retries: 3
   delay: 10
   until: download_result is success
-  run_once: "{{ splunk_download_local }}"
+  throttle: "{{ 1 if splunk_download_local else 0 }}"
 
 - name: "Unarchive Splunk {{ splunk_install_type }} package to {{ splunk_home }}"
   ansible.builtin.unarchive:


### PR DESCRIPTION
## Summary

- Remove `run_once` from the download task, which prevented the second package type from being downloaded in mixed-type plays (e.g., `full` + `uf` in the same inventory)
- `ansible.builtin.get_url` is idempotent - it checks whether the file already exists at `dest` before downloading, so removing `run_once` does not cause redundant downloads

## Problem

When a play targets both `full` and `uf` hosts, `run_once: "{{ splunk_download_local }}"` caused only the first host's package type to be downloaded. All hosts of the other install type would fail because their package was never fetched.

## Verification

Tested with a mixed inventory (2 full + 2 uf hosts). Both packages are downloaded exactly once:

```
TASK [../roles/splunk : Download Splunk uf package]
changed: [uf1 -> localhost]
ok: [uf2 -> localhost]
changed: [hf1 -> localhost]
ok: [hf2 -> localhost]
```

```
$ ls -l ~/splunk*10.2*
-rw-rw-r-- 1 ubuntu ubuntu 1745523825 Mar 13 12:08 splunk-10.2.1-c892b66d163d-linux-amd64.tgz
-rw-rw-r-- 1 ubuntu ubuntu  126111624 Mar 13 12:06 splunkforwarder-10.2.1-c892b66d163d-linux-amd64.tgz
```

The first host per package type shows `changed` (actual download), subsequent hosts show `ok` (file already exists).

Fixes #176