### PR TITLE
Update deploy app task and restart handler

### DIFF
--- a/roles/splunk/handlers/main.yml
+++ b/roles/splunk/handlers/main.yml
@@ -70,7 +70,9 @@
     name: "{{ splunk_service }}"
     state: restarted
   become: true
-  when: not start_splunk_handler_fired
+  when:
+    - not start_splunk_handler_fired
+    - not skip_splunk_restart | default(false)
 
 - name: restart redhat auditd service
   ansible.builtin.shell: |

--- a/roles/splunk/tasks/configure_apps.yml
+++ b/roles/splunk/tasks/configure_apps.yml
@@ -51,6 +51,20 @@
       delegate_to: localhost
       changed_when: false
       check_mode: false
+      retries: 10
+      delay: 10
+      register: git_clone_result
+      until: git_clone_result is not failed
+
+    - name: Set ownership of cloned repos to splunk user
+      ansible.builtin.file:
+        path: "{{ git_local_clone_path }}{{ ansible_nodename }}"
+        owner: "{{ splunk_nix_user }}"
+        group: "{{ splunk_nix_group }}"
+        recurse: true
+      delegate_to: localhost
+      become: true
+      changed_when: false
 
     - name: Ensure rsync is installed on target host
       ansible.builtin.package:


### PR DESCRIPTION
This PR creates an option in the restart Splunk handler in cases where you don't want Splunk to restart yet. In addition, I added retries option to the git clone task in the app deployment task as there can be transient ssh errors when performing the clone. I also added a task to set the ownership of the clone path so it's easier to synchronize the apps when running the task on the Ansible controller.