### PR TITLE
Fix #263: move app ownership chown to target host, revert SHC check

### DIFF
--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -83,6 +83,7 @@ splunk_shc_target_group: shc
 splunk_shc_deployer: "{{ groups['shdeployer'] | first }}"  # If you manage multiple SHCs, configure the var value in group_vars
 splunk_shc_uri_list: "{% for h in groups[splunk_shc_target_group] %}https://{{ hostvars[h].splunk_mgmt_uri }}:{{ splunkd_port }}{% if not loop.last %},{% endif %}{% endfor %}"  # If you manage multiple SHCs, configure the var value in group_vars
 start_splunk_handler_fired: false  # Do not change; used to prevent unnecessary splunk restarts
+skip_splunk_restart: false  # Set to true to suppress the "restart splunk" handler (e.g. during maintenance windows where you want to defer restarts)
 # Linux and scripting related vars
 add_crashlog_script: false  # Set to true to install a script and cron job to automatically cleanup splunk crash logs older than 7 days
 add_diag_script: false  # Set to true to install a script and cron job to automatically cleanup splunk diag files older than 30 days

--- a/roles/splunk/handlers/main.yml
+++ b/roles/splunk/handlers/main.yml
@@ -72,7 +72,7 @@
   become: true
   when:
     - not start_splunk_handler_fired
-    - not skip_splunk_restart | default(false)
+    - not (skip_splunk_restart | default(false) | bool)
 
 - name: restart redhat auditd service
   ansible.builtin.shell: |

--- a/roles/splunk/tasks/configure_apps.yml
+++ b/roles/splunk/tasks/configure_apps.yml
@@ -56,16 +56,6 @@
       register: git_clone_result
       until: git_clone_result is not failed
 
-    - name: Set ownership of cloned repos to splunk user
-      ansible.builtin.file:
-        path: "{{ git_local_clone_path }}{{ ansible_nodename }}"
-        owner: "{{ splunk_nix_user }}"
-        group: "{{ splunk_nix_group }}"
-        recurse: true
-      delegate_to: localhost
-      become: true
-      changed_when: false
-
     - name: Ensure rsync is installed on target host
       ansible.builtin.package:
         name: rsync
@@ -87,53 +77,6 @@
         - "Defaults    requiretty"
       become: true
 
-    - name: Check if correct vars are defined for SHC app management
-      block:
-        - name: Trigger failure if target_shc_group_name var is undefined
-          ansible.builtin.fail:
-            msg: "Please add a target_shc_group_name variable to the host_vars for your SH Deployer host(s) before proceeding."
-          when: target_shc_group_name is not defined
-
-        - name: Trigger failure if splunk_admin_username var is undefined
-          ansible.builtin.fail:
-            msg: "Please add a splunk_admin_username variable to the host_vars for your SHC hosts before proceeding."
-          when: splunk_admin_username is not defined
-
-        - name: Trigger failure if splunk_admin_password var is undefined
-          ansible.builtin.fail:
-            msg:
-              - "Please add a splunk_admin_password variable to the host_vars or group_vars for your SHC hosts before proceeding."
-              - "Tip: To encrypt the var value, you can use: ansible-vault encrypt_string --ask-vault-pass 'var_value_to_encrypt' --name 'splunk_admin_password' then, use the --ask-vault-pass argument when running the play."
-          when: splunk_admin_password is not defined
-
-        - name: Get SHC status from first SH under the "target_shc_group_name" inventory group specified in the shdeployer host_vars
-          ansible.builtin.uri:
-            url: "https://{{ groups[target_shc_group_name] | first }}:{{ splunkd_port }}/services/shcluster/status"
-            method: GET
-            user: "{{ splunk_admin_username }}"
-            password: "{{ splunk_admin_password }}"
-            validate_certs: false
-            return_content: true
-            status_code: 200
-            body: output_mode=json
-          check_mode: false
-          no_log: true
-          changed_when: false
-          register: shc_status_response
-
-        - name: Set vars for deployment based on SHC status
-          ansible.builtin.set_fact:
-            service_ready_state: "{{ shc_status_response.json.entry[0].content.captain.service_ready_flag }}"
-            deploy_target: "{{ shc_status_response.json.entry[0].content.captain.mgmt_uri }}"
-
-        - name: Trigger failure if SHC is NOT ready
-          ansible.builtin.fail:
-            msg: "The SHC has service ready state of FALSE. Please investigate and re-run Ansible play after resolving."
-          when:
-            - not service_ready_state
-
-      when: "'shdeployer' in group_names"
-
     - name: Install apps
       ansible.builtin.include_tasks: install_apps.yml
       loop: "{{ git_apps }}"
@@ -145,6 +88,15 @@
               else 'reload deployment server' if app_dest == 'etc/deployment-apps'
               else 'apply shcluster-bundle' if app_dest == 'etc/shcluster/apps'
               else 'restart splunk' }}
+
+    - name: Ensure correct ownership of deployed apps on target host
+      ansible.builtin.file:
+        path: "{{ splunk_home }}/{{ item }}"
+        owner: "{{ splunk_nix_user }}"
+        group: "{{ splunk_nix_group }}"
+        recurse: true
+      become: true
+      loop: "{{ git_apps | map(attribute='splunk_app_deploy_path', default=splunk_app_deploy_path) | unique | list }}"
 
     - name: Cleanup the local directory that was used to manage repos on the target host
       ansible.builtin.file:

--- a/roles/splunk/tasks/install_apps.yml
+++ b/roles/splunk/tasks/install_apps.yml
@@ -1,6 +1,52 @@
 ---
 # This task MUST be called by configure_apps.yml to work correctly. Do NOT call this task directly via the deployment_task var!
 
+- name: Check if correct vars are defined for SHC app management
+  block:
+    - name: Trigger failure if target_shc_group_name var is undefined
+      ansible.builtin.fail:
+        msg: "Please add a target_shc_group_name variable to the host_vars for your SH Deployer host(s) before proceeding."
+      when: target_shc_group_name is not defined
+
+    - name: Trigger failure if splunk_admin_username var is undefined
+      ansible.builtin.fail:
+        msg: "Please add a splunk_admin_username variable to the host_vars for your SHC hosts before proceeding."
+      when: splunk_admin_username is not defined
+
+    - name: Trigger failure if splunk_admin_password var is undefined
+      ansible.builtin.fail:
+        msg:
+          - "Please add a splunk_admin_password variable to the host_vars or group_vars for your SHC hosts before proceeding."
+          - "Tip: To encrypt the var value, you can use: ansible-vault encrypt_string --ask-vault-pass 'var_value_to_encrypt' --name 'splunk_admin_password' then, use the --ask-vault-pass argument when running the play."
+      when: splunk_admin_password is not defined
+
+    - name: Get SHC status from first SH under the "target_shc_group_name" inventory group specified in the shdeployer host_vars
+      ansible.builtin.uri:
+        url: "https://{{ groups[target_shc_group_name] | first }}:{{ splunkd_port }}/services/shcluster/status"
+        method: GET
+        user: "{{ splunk_admin_username }}"
+        password: "{{ splunk_admin_password }}"
+        validate_certs: false
+        return_content: true
+        status_code: 200
+        body: output_mode=json
+      check_mode: false
+      no_log: true
+      changed_when: false
+      register: shc_status_response
+
+    - name: Set vars for deployment based on SHC status
+      ansible.builtin.set_fact:
+        service_ready_state: "{{ shc_status_response.json.entry[0].content.captain.service_ready_flag | bool }}"
+        deploy_target: "{{ shc_status_response.json.entry[0].content.captain.mgmt_uri }}"
+
+    - name: Trigger failure if SHC is NOT ready
+      ansible.builtin.fail:
+        msg: "The SHC has service ready state of FALSE. Please investigate and re-run Ansible play after resolving."
+      when: not service_ready_state
+
+  when: handler == "apply shcluster-bundle"
+
 # Note: By using the synchronize module, if the repo already exists on the target host, we are able to only update the diff while preserving the local/ folder
 - name: "Synchronize {{ item.name }} repo from local Ansible host to {{ splunk_home }}/{{ app_dest }}/{{ item.name }} on remote host"
   ansible.posix.synchronize:
@@ -13,6 +59,8 @@
     rsync_opts:
       - "--prune-empty-dirs"
       - "--itemize-changes"
+      - "--no-owner"
+      - "--no-group"
       - "--no-times"
   become: true
   become_user: "{{ splunk_nix_user }}"


### PR DESCRIPTION
## Summary

Fixes #263. The controller-side chown added in PR #261 fails on Ansible
controllers (e.g. AWX) that don't have a local splunk user. This PR moves
ownership enforcement back to the target host and addresses adjacent
regressions from PRs #261/#262.

## Changes

- **`configure_apps.yml`**
  - Remove the failing controller-side chown (fixes #263)
  - Remove the `'shdeployer' in group_names` SHC check block (moved back)
  - Add a post-loop remote chown that runs once per unique
    `splunk_app_deploy_path`, preserving the "not per-repo" optimization

- **`install_apps.yml`**
  - Restore `--no-owner` / `--no-group` in rsync_opts
  - Revert PR #262's SHC check move - block is back in the loop with the
    original per-app gate `when: handler == "apply shcluster-bundle"`.
    PR #262's `'shdeployer' in group_names` proxy was not semantically
    equivalent: it over-fired for shdeployers pushing only to `etc/apps`
    and silently skipped for non-shdeployers with a per-app override to
    `etc/shcluster/apps` (apps synced but SHC bundle never applied)
  - Add `| bool` on `service_ready_state` to fix the pre-existing
    string-truthiness bug

- **`handlers/main.yml`**: wrap `skip_splunk_restart` in `| bool`
- **`defaults/main.yml`**: declare `skip_splunk_restart: false` (PR #261
  introduced the toggle but never added it to defaults)

## Cost of the SHC revert

SHC plays now make N REST calls to the captain instead of 1. This matches
pre-PR-262 behavior that ran in production for years. Can be addressed in
a follow-up PR by gating on a precomputed set of effective deploy paths,
preserving the once-per-host optimization without the proxy's edge cases.