### PR TITLE
Fix for issue #266 optimize deploy path issues

### DIFF
--- a/roles/splunk/tasks/configure_apps.yml
+++ b/roles/splunk/tasks/configure_apps.yml
@@ -1,29 +1,29 @@
 ---
 # Configure default splunk_app_deploy_path based on which group the host is a member of
-- block:
-  - name: Set default splunk_app_deploy_path for clustermanager hosts
-    ansible.builtin.set_fact:
-      splunk_app_deploy_path: etc/master-apps
-    when: "'clustermanager' in group_names"
+- name: Set default splunk_app_deploy_path based on group membership
+  block:
+    - name: Set default splunk_app_deploy_path for clustermanager hosts
+      ansible.builtin.set_fact:
+        splunk_app_deploy_path: etc/master-apps
+      when: "'clustermanager' in group_names"
 
-  - name: Set default splunk_app_deploy_path for shdeployer hosts
-    ansible.builtin.set_fact:
-      splunk_app_deploy_path: etc/shcluster/apps
-    when: "'shdeployer' in group_names"
+    - name: Set default splunk_app_deploy_path for shdeployer hosts
+      ansible.builtin.set_fact:
+        splunk_app_deploy_path: etc/shcluster/apps
+      when: "'shdeployer' in group_names"
 
-  - name: Set default splunk_app_deploy_path for deploymentserver hosts
-    ansible.builtin.set_fact:
-      splunk_app_deploy_path: etc/deployment-apps
-    when: "'deploymentserver' in group_names"
+    - name: Set default splunk_app_deploy_path for deploymentserver hosts
+      ansible.builtin.set_fact:
+        splunk_app_deploy_path: etc/deployment-apps
+      when: "'deploymentserver' in group_names"
 
-  - name: "Set default splunk_app_deploy_path all other hosts"
-    ansible.builtin.set_fact:
-      splunk_app_deploy_path: "etc/apps"
-    when:
-      - "'clustermanager' not in group_names"
-      - "'shdeployer' not in group_names"
-      - "'deploymentserver' not in group_names"
-  # Conditional for block
+    - name: "Set default splunk_app_deploy_path all other hosts"
+      ansible.builtin.set_fact:
+        splunk_app_deploy_path: "etc/apps"
+      when:
+        - "'clustermanager' not in group_names"
+        - "'shdeployer' not in group_names"
+        - "'deploymentserver' not in group_names"
   when: splunk_app_deploy_path is undefined or splunk_app_deploy_path == 'undefined'
 
 # Prep the Ansible host to deploy apps then install them

--- a/roles/splunk/tasks/configure_apps.yml
+++ b/roles/splunk/tasks/configure_apps.yml
@@ -1,27 +1,30 @@
 ---
 # Configure default splunk_app_deploy_path based on which group the host is a member of
-- name: Set default splunk_app_deploy_path for clustermanager hosts
-  ansible.builtin.set_fact:
-    splunk_app_deploy_path: etc/master-apps
-  when: "'clustermanager' in group_names"
+- block:
+  - name: Set default splunk_app_deploy_path for clustermanager hosts
+    ansible.builtin.set_fact:
+      splunk_app_deploy_path: etc/master-apps
+    when: "'clustermanager' in group_names"
 
-- name: Set default splunk_app_deploy_path for shdeployer hosts
-  ansible.builtin.set_fact:
-    splunk_app_deploy_path: etc/shcluster/apps
-  when: "'shdeployer' in group_names"
+  - name: Set default splunk_app_deploy_path for shdeployer hosts
+    ansible.builtin.set_fact:
+      splunk_app_deploy_path: etc/shcluster/apps
+    when: "'shdeployer' in group_names"
 
-- name: Set default splunk_app_deploy_path for deploymentserver hosts
-  ansible.builtin.set_fact:
-    splunk_app_deploy_path: etc/deployment-apps
-  when: "'deploymentserver' in group_names"
+  - name: Set default splunk_app_deploy_path for deploymentserver hosts
+    ansible.builtin.set_fact:
+      splunk_app_deploy_path: etc/deployment-apps
+    when: "'deploymentserver' in group_names"
 
-- name: "Set default splunk_app_deploy_path all other hosts"
-  ansible.builtin.set_fact:
-    splunk_app_deploy_path: "etc/apps"
-  when:
-    - "'clustermanager' not in group_names"
-    - "'shdeployer' not in group_names"
-    - "'deploymentserver' not in group_names"
+  - name: "Set default splunk_app_deploy_path all other hosts"
+    ansible.builtin.set_fact:
+      splunk_app_deploy_path: "etc/apps"
+    when:
+      - "'clustermanager' not in group_names"
+      - "'shdeployer' not in group_names"
+      - "'deploymentserver' not in group_names"
+  # Conditional for block
+  when: "splunk_app_deploy_path is undefined"
 
 # Prep the Ansible host to deploy apps then install them
 - block:

--- a/roles/splunk/tasks/configure_apps.yml
+++ b/roles/splunk/tasks/configure_apps.yml
@@ -24,7 +24,7 @@
       - "'shdeployer' not in group_names"
       - "'deploymentserver' not in group_names"
   # Conditional for block
-  when: "splunk_app_deploy_path is undefined"
+  when: splunk_app_deploy_path is undefined or splunk_app_deploy_path == 'undefined'
 
 # Prep the Ansible host to deploy apps then install them
 - block:

--- a/roles/splunk/tasks/configure_apps.yml
+++ b/roles/splunk/tasks/configure_apps.yml
@@ -98,7 +98,7 @@
         app_dest: "{{ item.splunk_app_deploy_path | default(splunk_app_deploy_path) }}"
         app_src: "{{ git_local_clone_path }}{{ ansible_nodename }}/{{ item.name }}{{ item.app_relative_path | default(app_relative_path) }}"
         handler: >-
-          {{ 'apply indexer cluster bundle' if app_dest == 'etc/master-apps'
+          {{ 'apply indexer cluster bundle' if app_dest == 'etc/master-apps' or app_dest == 'etc/manager-apps'
               else 'reload deployment server' if app_dest == 'etc/deployment-apps'
               else 'apply shcluster-bundle' if app_dest == 'etc/shcluster/apps'
               else 'restart splunk' }}


### PR DESCRIPTION
This PR closes #266 

Enclosed several set_fact for default deployment paths in a block that only runs when `splunk_app_deploy_path` is undefined.
That allows for the role to use values from host or group vars when already set.

Added an `or` so that the handler to deploy indexer cluster bundle works also when the target folder is `etc/manager-apps` and not only when deploy path was `etc/master-apps`.